### PR TITLE
Go back to using INI for configs

### DIFF
--- a/cmake/3rd_party.cmake
+++ b/cmake/3rd_party.cmake
@@ -43,13 +43,6 @@ FetchContent_Declare(
 )
 
 FetchContent_Declare(
-    toml11
-    GIT_REPOSITORY https://github.com/ToruNiina/toml11.git
-    GIT_TAG        v4.4.0
-    GIT_SHALLOW    ON
-)
-
-FetchContent_Declare(
     entt
     GIT_REPOSITORY https://github.com/skypjack/entt.git
     GIT_TAG        v3.15.0
@@ -62,7 +55,7 @@ FetchContent_Declare(
     GIT_TAG         f4c7a52c668365118dcf712fa4efabebfe44c53c
 )
 
-FetchContent_MakeAvailable(Catch2 fast_float sentry spdlog toml11 entt storm-audio)
+FetchContent_MakeAvailable(Catch2 fast_float sentry spdlog entt storm-audio)
 
 if (WIN32)
     FetchContent_MakeAvailable(SDL2 zlib)

--- a/cmake/3rd_party.cmake
+++ b/cmake/3rd_party.cmake
@@ -59,7 +59,7 @@ FetchContent_Declare(
 FetchContent_Declare(
     storm-audio
     GIT_REPOSITORY  https://github.com/WillTer/storm-audio.git
-    GIT_TAG         1f7544fad34178d65d9a42d688d17282bbe9502e
+    GIT_TAG         f4c7a52c668365118dcf712fa4efabebfe44c53c
 )
 
 FetchContent_MakeAvailable(Catch2 fast_float sentry spdlog toml11 entt storm-audio)

--- a/src/libs/animals/t_butterflies.cpp
+++ b/src/libs/animals/t_butterflies.cpp
@@ -25,7 +25,7 @@ TButterflies::~TButterflies()
 //--------------------------------------------------------------------
 void TButterflies::LoadSettings()
 {
-    auto ini = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Config) / ANIMALS_INI_FILE);
+    auto ini = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Ini) / ANIMALS_INI_FILE);
     if (!ini) return;
 
     butterfliesCount = ini->GetInt(ANIMALS_BUTTERFLIES_SECTION, "count", BUTTERFLY_COUNT);

--- a/src/libs/animals/t_fish_schools.cpp
+++ b/src/libs/animals/t_fish_schools.cpp
@@ -27,7 +27,7 @@ TFishSchools::~TFishSchools()
 //--------------------------------------------------------------------
 void TFishSchools::LoadSettings()
 {
-    auto ini = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Config) / ANIMALS_INI_FILE);
+    auto ini = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Ini) / ANIMALS_INI_FILE);
     if (!ini) return;
 
     fishSchoolsCount = ini->GetInt(ANIMALS_FISHSCHOOLS_SECTION, "count", FISHSCHOOL_COUNT);

--- a/src/libs/animals/t_seagulls.cpp
+++ b/src/libs/animals/t_seagulls.cpp
@@ -13,7 +13,10 @@
 // #pragma warning (disable : 4244)
 
 //--------------------------------------------------------------------
-TSeagulls::TSeagulls() : enabled(true), count(0), frightened(false) {}
+TSeagulls::TSeagulls() : enabled(true), count(0), frightened(false)
+{
+    std::memset(seagulls, 0, sizeof(seagulls));
+}
 
 //--------------------------------------------------------------------
 TSeagulls::~TSeagulls()

--- a/src/libs/animals/t_seagulls.cpp
+++ b/src/libs/animals/t_seagulls.cpp
@@ -24,7 +24,7 @@ TSeagulls::~TSeagulls()
 //--------------------------------------------------------------------
 void TSeagulls::LoadSettings()
 {
-    auto ini = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Config) / ANIMALS_INI_FILE);
+    auto ini = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Ini) / ANIMALS_INI_FILE);
     if (!ini) {
         countAdd        = SEAGULL_ADD_COUNT;
         maxRadius       = SEAGULL_MAX_RADIUS;

--- a/src/libs/animation/bone.cpp
+++ b/src/libs/animation/bone.cpp
@@ -27,8 +27,8 @@ Bone::Bone()
 
 Bone::~Bone()
 {
-    delete ang;
-    delete pos;
+    delete[] ang;
+    delete[] pos;
 }
 
 // how many frames of animation there will be

--- a/src/libs/ball_splash/ball_splash.cpp
+++ b/src/libs/ball_splash/ball_splash.cpp
@@ -132,7 +132,7 @@ void BallSplash::Execute(uint32_t dTime)
 void BallSplash::InitializeSplashes()
 {
     // FIXME: hardcode
-    auto psIni = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Config) / "particles.ini");
+    auto psIni = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Ini) / "particles.ini");
 
     for (auto i = 0; i < MAX_SPLASHES; ++i) {
         splashes[i].Release();

--- a/src/libs/battle_interface/active_perk_shower.cpp
+++ b/src/libs/battle_interface/active_perk_shower.cpp
@@ -352,12 +352,15 @@ void ActivePerkShower::ReleaseAll()
 
     for (i = 0; i < m_nTextureQ; i++)
         TEXTURE_RELEASE(rs, m_pTexDescr[i].m_idTexture);
-    STORM_DELETE(m_pTexDescr);
+    delete[] m_pTexDescr;
+    m_pTexDescr = nullptr;
     m_nTextureQ = 0;
 
-    STORM_DELETE(m_pShowPlaces);
+    delete[] m_pShowPlaces;
+    m_pShowPlaces = nullptr;
     m_nShowPlaceQ = 0;
 
-    STORM_DELETE(m_pIconsList);
-    m_nIShowQ = 0;
+    delete[] m_pIconsList;
+    m_pIconsList = nullptr;
+    m_nIShowQ    = 0;
 }

--- a/src/libs/battle_interface/land/battle_man_sign.cpp
+++ b/src/libs/battle_interface/land/battle_man_sign.cpp
@@ -36,6 +36,7 @@ BIManSign::BIManSign(entid_t BIEntityID, VDX9RENDER* pRS)
 
     m_nCurrentManIndex = 0;
 
+    std::memset(m_Man, 0, sizeof(m_Man));
     for (int32_t n = 0; n < MAX_MAN_QUANTITY; n++)
         m_Man[n].nTexture = -1;
 

--- a/src/libs/blade/blade.cpp
+++ b/src/libs/blade/blade.cpp
@@ -189,6 +189,8 @@ Blade::Blade()
 {
     gunLocName = gunBeltName;
     blendValue = 0xFFFFFFFF;
+    man        = {};
+    gun        = {};
 }
 
 Blade::~Blade()

--- a/src/libs/config/CMakeLists.txt
+++ b/src/libs/config/CMakeLists.txt
@@ -2,12 +2,8 @@ storm_lib(
     NAME config
     LINK_DEPENDENCIES
         core
-    HEADER_DEPENDENCIES
-        toml11::toml11
 )
 
 storm_headers(
     NAME config_iface
-    HEADER_DEPENDENCIES
-        toml11::toml11
 )

--- a/src/libs/config/config_loader.cpp
+++ b/src/libs/config/config_loader.cpp
@@ -2,31 +2,31 @@
 
 #include <libs/core/core.h>
 #include <libs/filesystem/v_file_service.h>
-#include <toml.hpp>
+
+#include "ini_file.h"
 
 using namespace storm;
 
-toml::value ConfigLoader::open_config(std::filesystem::path const& path)
+std::unique_ptr<IniFile> ConfigLoader::open_config(std::filesystem::path const& path)
 {
     if (!fio->exists(path)) {
-        core->Trace("Config file \"%s\" not found", path.string().c_str());
+        core->Trace("Config file \"%s\" not found", fio->transform_path(path).string().c_str());
         return {};
     }
 
-    if (path.extension().string() != ".toml") {
+    if (path.extension().string() != ".ini") {
         core->Trace("Config file \"%s\" was not loaded - extension is not supported", path.string().c_str());
         return {};
     }
 
-    auto file_stream = fio->open_file<std::ifstream>(path, std::ios::binary);
-    return toml::parse(file_stream);
+    return std::make_unique<IniFile>(path);
 }
 
-toml::value ConfigLoader::open_config_cached(std::filesystem::path const& path)
+IniFile const& ConfigLoader::open_config_cached(std::filesystem::path const& path)
 {
     // Add to cache even if load fails
     // Then try to parse file again when someone asks it
-    if (!m_files.contains(path) || m_files.at(path).is_empty()) { m_files[path] = open_config(path); }
+    if (!m_files.contains(path) || m_files.at(path)->is_empty()) { m_files[path] = open_config(path); }
 
-    return m_files.at(path);
+    return *m_files.at(path);
 }

--- a/src/libs/config/config_loader.cpp
+++ b/src/libs/config/config_loader.cpp
@@ -24,9 +24,12 @@ std::unique_ptr<IniFile> ConfigLoader::open_config(std::filesystem::path const& 
 
 IniFile const& ConfigLoader::open_config_cached(std::filesystem::path const& path)
 {
-    // Add to cache even if load fails
-    // Then try to parse file again when someone asks it
-    if (!m_files.contains(path) || m_files.at(path)->is_empty()) { m_files[path] = open_config(path); }
+    if (!m_files.contains(path)) {
+        auto config = open_config(path);
+        if (!config) { throw std::runtime_error("Could not open config file"); }
+
+        m_files.emplace(path, std::move(config));
+    }
 
     return *m_files.at(path);
 }

--- a/src/libs/config/config_loader.h
+++ b/src/libs/config/config_loader.h
@@ -4,6 +4,7 @@
 #include <unordered_map>
 
 #include "i_config_loader.h"
+#include "ini_file.h"
 
 namespace storm
 {
@@ -11,11 +12,11 @@ namespace storm
 class ConfigLoader final: virtual public IConfigLoader
 {
 public:
-    toml::value open_config(std::filesystem::path const& path) override;
-    toml::value open_config_cached(std::filesystem::path const& path) override;
+    std::unique_ptr<IniFile> open_config(std::filesystem::path const& path) override;
+    IniFile const&           open_config_cached(std::filesystem::path const& path) override;
 
 private:
-    std::unordered_map<std::filesystem::path, toml::value> m_files;
+    std::unordered_map<std::filesystem::path, std::unique_ptr<IniFile>> m_files;
 };
 
 }  // namespace storm

--- a/src/libs/config/i_config_loader.h
+++ b/src/libs/config/i_config_loader.h
@@ -2,8 +2,6 @@
 
 #include <filesystem>
 
-#include <toml_fwd.hpp>
-
 namespace storm
 {
 

--- a/src/libs/config/i_config_loader.h
+++ b/src/libs/config/i_config_loader.h
@@ -7,13 +7,15 @@
 namespace storm
 {
 
+class IniFile;
+
 class IConfigLoader
 {
 public:
     virtual ~IConfigLoader() = default;
 
-    virtual toml::value open_config(std::filesystem::path const& path)        = 0;
-    virtual toml::value open_config_cached(std::filesystem::path const& path) = 0;
+    virtual std::unique_ptr<IniFile> open_config(std::filesystem::path const& path)        = 0;
+    virtual IniFile const&           open_config_cached(std::filesystem::path const& path) = 0;
 };
 
 }  // namespace storm

--- a/src/libs/config/ini_file.cpp
+++ b/src/libs/config/ini_file.cpp
@@ -1,0 +1,149 @@
+#include "ini_file.h"
+
+#include <string_view>
+
+#include <libs/core/core.h>
+#include <libs/filesystem/v_file_service.h>
+
+using namespace storm;
+
+namespace
+{
+
+constexpr std::string_view DEFAULT_SECTION_NAME = "";
+
+constexpr char WHITESPACE_CHARACTERS[] = "\r\n\t ";
+constexpr char NEWLINE_CHARACTERS[]    = "\r\n";
+
+constexpr char INI_SECTION_START   = '[';
+constexpr char INI_SECTION_END     = ']';
+constexpr char INI_COMMENT_START[] = ";#";
+constexpr char INI_VALUE_START     = '=';
+constexpr char INI_VALUE_END[]     = "\r\n;#";
+
+std::pair<std::string_view, IniFile::Section> read_section(std::string_view const& str, size_t& offset)
+{
+    auto const skip_to_next_line = [&str](size_t current_offset) {
+        current_offset = str.find_first_of(NEWLINE_CHARACTERS, current_offset);
+        if (current_offset != std::string_view::npos) { current_offset = str.find_first_not_of(WHITESPACE_CHARACTERS, current_offset); }
+        return current_offset;
+    };
+
+    auto const trim = [](std::string_view const& s) -> std::string {
+        auto const start = s.find_first_not_of(WHITESPACE_CHARACTERS);
+        auto const end   = s.find_last_not_of(WHITESPACE_CHARACTERS);
+        if (start == std::string_view::npos || end == std::string_view::npos) { return {}; }  // If there is only spaces return empty string
+
+        return std::string(s.substr(start, std::min(end - start + 1, s.size() - start)));  // Add 1 to preserve last character
+    };
+
+    std::string_view section_name = DEFAULT_SECTION_NAME;
+    if (str.at(offset) == INI_SECTION_START) {  // Read section name if we at the section start
+        auto const section_end = str.find_first_of(INI_SECTION_END, offset);
+        section_name           = str.substr(offset + 1, section_end - (offset + 1));
+
+        // Skip until next line start after we read section name
+        offset = skip_to_next_line(section_end);
+    }
+
+    IniFile::Section section = {};
+    while (offset < str.size() && str.at(offset) != INI_SECTION_START) {
+        if (str.at(offset) == INI_COMMENT_START[0] || str.at(offset) == INI_COMMENT_START[1]) {
+            offset = skip_to_next_line(offset);
+            continue;
+        }
+
+        auto const value_start = str.find_first_of(INI_VALUE_START, offset);  // Find '=' sign
+        if (value_start == std::string_view::npos) {
+            core->Trace("Ini file syntax error: no '=' after key name \"%s\"", str.substr(offset).data());
+            offset = skip_to_next_line(offset);
+            continue;
+        }
+
+        auto const value_end = str.find_first_of(INI_VALUE_END, value_start);  // Find newline or comment start after equals
+
+        auto const key = str.substr(offset, value_start - offset);  // Read the key from start until '='
+        auto const value = str.substr(  // Read the value from '=' (skip equals sign itself) until line (or file) end
+            value_start + 1,
+            value_end != std::string_view::npos
+                ? value_end - (value_start + 1)
+                : std::string_view::npos);
+
+        section.emplace(trim(key), trim(value));
+
+        offset = skip_to_next_line(offset);  // Skip to next line start
+    }
+
+    return std::make_pair(section_name, section);
+}
+
+}  // namespace
+
+IniFile::IniFile(std::filesystem::path const& file_path)
+{
+    if (!fio->exists(file_path)) {
+        core->Trace("IniFile::IniFile(): file not found (\"%s\")", fio->transform_path(file_path).string().c_str());
+        return;
+    }
+
+    std::vector<char> file_data = {};
+    if (!fio->read_file_to_mem(file_path, file_data)) {
+        core->Trace("IniFile::IniFile(): file read error (\"%s\")", fio->transform_path(file_path).string().c_str());
+        return;
+    }
+
+    auto const content = std::string_view(file_data.begin(), file_data.end());
+    size_t     offset  = 0;
+
+    while (offset < content.size()) {
+        auto const [section_name, section_table] = read_section(content, offset);
+        m_table.emplace(std::string(section_name), section_table);
+    }
+}
+
+std::optional<std::string> IniFile::try_get_string(std::string const& section, std::string const& key) const
+{
+    if (!m_table.contains(section) || !m_table.at(section).contains(key)) { return std::nullopt; }
+
+    auto const& s           = m_table.at(section);
+    auto const [begin, end] = s.equal_range(key);
+
+    return begin->second;
+}
+
+std::string IniFile::get_string(std::string const& section, std::string const& key) const
+{
+    if (auto const value = try_get_string(section, key); value.has_value()) { return value.value(); }
+
+    throw std::runtime_error(std::format("IniFile: key (\"{}\") or section (\"{}\") not found ", key, section));
+}
+
+std::vector<std::string> IniFile::get_vector(std::string const& section, std::string const& key) const
+{
+    if (!m_table.contains(section) || !m_table.at(section).contains(key)) { return {}; }
+
+    auto const& s           = m_table.at(section);
+    auto const [begin, end] = s.equal_range(key);
+
+    auto vec = std::vector<std::string> {};
+    for (auto it = begin; it != end; ++it) {
+        vec.emplace_back(it->second);
+    }
+
+    return vec;
+}
+
+bool IniFile::is_empty() const
+{
+    return m_table.empty();
+}
+
+IniFile::Section const& IniFile::get_section(std::string const& section) const
+{
+    return m_table.at(section);
+}
+
+std::unordered_map<std::string, IniFile::Section> const& IniFile::get_sections() const
+{
+    return m_table;
+}

--- a/src/libs/config/ini_file.cpp
+++ b/src/libs/config/ini_file.cpp
@@ -1,5 +1,6 @@
 #include "ini_file.h"
 
+#include <cassert>
 #include <string_view>
 
 #include <libs/core/core.h>
@@ -10,68 +11,108 @@ using namespace storm;
 namespace
 {
 
-constexpr std::string_view DEFAULT_SECTION_NAME = "";
-
-constexpr char WHITESPACE_CHARACTERS[] = "\r\n\t ";
+constexpr char WHITESPACE_CHARACTERS[] = "\t ";
 constexpr char NEWLINE_CHARACTERS[]    = "\r\n";
 
 constexpr char INI_SECTION_START   = '[';
 constexpr char INI_SECTION_END     = ']';
 constexpr char INI_COMMENT_START[] = ";#";
-constexpr char INI_VALUE_START     = '=';
-constexpr char INI_VALUE_END[]     = "\r\n;#";
 
-std::pair<std::string_view, IniFile::Section> read_section(std::string_view const& str, size_t& offset)
+constexpr char KEY_VALUE_SEP   = '=';
+constexpr char KEY_VALUE_END[] = ";#";
+
+std::string get_section_name(std::string_view const& str, std::string const& ini_file_name, size_t const ini_file_line)
 {
-    auto const skip_to_next_line = [&str](size_t current_offset) {
-        current_offset = str.find_first_of(NEWLINE_CHARACTERS, current_offset);
-        if (current_offset != std::string_view::npos) { current_offset = str.find_first_not_of(WHITESPACE_CHARACTERS, current_offset); }
-        return current_offset;
-    };
-
-    auto const trim = [](std::string_view const& s) -> std::string {
-        auto const start = s.find_first_not_of(WHITESPACE_CHARACTERS);
-        auto const end   = s.find_last_not_of(WHITESPACE_CHARACTERS);
-        if (start == std::string_view::npos || end == std::string_view::npos) { return {}; }  // If there is only spaces return empty string
-
-        return std::string(s.substr(start, std::min(end - start + 1, s.size() - start)));  // Add 1 to preserve last character
-    };
-
-    std::string_view section_name = DEFAULT_SECTION_NAME;
-    if (str.at(offset) == INI_SECTION_START) {  // Read section name if we at the section start
-        auto const section_end = str.find_first_of(INI_SECTION_END, offset);
-        section_name           = str.substr(offset + 1, section_end - (offset + 1));
-
-        // Skip until next line start after we read section name
-        offset = skip_to_next_line(section_end);
+    // Read section name inside brackets: [<section_name>]
+    assert(str.at(0) == INI_SECTION_START);
+    auto const section_end = str.find_first_of(INI_SECTION_END);
+    if (section_end == std::string_view::npos) {
+        core->Trace(
+            "%s:%d: syntax error: no closing bracket (']') - section name ends unexpectedly\n\t%s",
+            ini_file_name.c_str(),
+            ini_file_line,
+            str.data());
+        return {};
     }
 
-    IniFile::Section section = {};
-    while (offset < str.size() && str.at(offset) != INI_SECTION_START) {
-        if (str.at(offset) == INI_COMMENT_START[0] || str.at(offset) == INI_COMMENT_START[1]) {
-            offset = skip_to_next_line(offset);
-            continue;
+    return std::string(str.substr(1, section_end - 1));  // Skip '[' and ']' characters
+}
+
+std::string trim(std::string_view const& str)
+{
+    auto const start = str.find_first_not_of(WHITESPACE_CHARACTERS);
+    auto const end   = str.find_last_not_of(WHITESPACE_CHARACTERS);
+    if (start == std::string_view::npos || end == std::string_view::npos) { return {}; }  // If there is only spaces return empty string
+
+    return std::string(str.substr(start, end - start + 1));  // Add 1 to preserve last character
+}
+
+std::pair<std::string, std::string>
+get_key_value_pair(std::string_view const& str, std::string const& ini_file_name, size_t const ini_file_line)
+{
+    auto const key_end = str.find_first_of(KEY_VALUE_SEP);  // Find '=' sign
+    if (key_end == std::string_view::npos) {
+        core->Trace("%s:%d: syntax error: no '=' after key name\n\t%s", ini_file_name.c_str(), ini_file_line, str.data());
+        return std::make_pair(std::string {}, std::string {});
+    }
+
+    auto const value_start = key_end + 1;                       // Skip '='
+    auto const value_end   = str.find_first_of(KEY_VALUE_END);  // Find comment start (or npos)
+
+    auto const key = str.substr(0, key_end);  // Read the key from the start until '='
+    auto const value = str.substr(  // Read the value after '=' until the end of the line or start of the comment
+        value_start,
+        value_end != std::string_view::npos
+            ? value_end - value_start
+            : std::string_view::npos);
+
+    return std::make_pair(trim(key), trim(value));
+}
+
+std::pair<std::string, IniFile::Section>
+read_section(std::string_view const& str, size_t& offset, std::string const& file_name, size_t& file_line)
+{
+    std::string      section_name = {};  // Empty section means global keys at the start of the file
+    IniFile::Section section      = {};
+
+    bool is_section_started = false;
+    bool is_section_ended   = false;
+    while (offset < str.size() && !is_section_ended) {
+        // Skip spaces and tabs at the line start
+        auto const line_start = str.find_first_not_of(WHITESPACE_CHARACTERS, offset);
+        if (line_start == std::string_view::npos) { break; }
+
+        auto const line_end = str.find_first_of(NEWLINE_CHARACTERS, line_start);
+        auto const line     = str.substr(line_start, line_end != std::string_view::npos ? line_end - line_start : std::string_view::npos);
+
+        if (!line.empty()) {
+            switch (line.at(0)) {
+            case INI_COMMENT_START[0]: [[fallthrough]];
+            case INI_COMMENT_START[1]: break;  // Skip comment line
+
+            case INI_SECTION_START:
+                if (!is_section_started) {
+                    section_name       = get_section_name(line, file_name, file_line);
+                    is_section_started = true;  // Section name is parsed, section is started
+                } else {
+                    is_section_ended = true;  // If there is another section start, then we're done with current section
+                }
+                break;
+
+            default: {
+                auto&& [key, value] = get_key_value_pair(line, file_name, file_line);
+                section.emplace(std::move(key), std::move(value));
+                is_section_started = true;  // If there is no section name, any read key means global section
+            } break;
+            }
         }
 
-        auto const value_start = str.find_first_of(INI_VALUE_START, offset);  // Find '=' sign
-        if (value_start == std::string_view::npos) {
-            core->Trace("Ini file syntax error: no '=' after key name \"%s\"", str.substr(offset).data());
-            offset = skip_to_next_line(offset);
-            continue;
+        // Keep offset if section is ended as we need to read another section from that place
+        if (!is_section_ended) {
+            // Move to next line. This statement allows us to skip both CRLF and LF
+            offset = str.find_first_of('\n', line_end) + 1;
+            ++file_line;
         }
-
-        auto const value_end = str.find_first_of(INI_VALUE_END, value_start);  // Find newline or comment start after equals
-
-        auto const key = str.substr(offset, value_start - offset);  // Read the key from start until '='
-        auto const value = str.substr(  // Read the value from '=' (skip equals sign itself) until line (or file) end
-            value_start + 1,
-            value_end != std::string_view::npos
-                ? value_end - (value_start + 1)
-                : std::string_view::npos);
-
-        section.emplace(trim(key), trim(value));
-
-        offset = skip_to_next_line(offset);  // Skip to next line start
     }
 
     return std::make_pair(section_name, section);
@@ -94,10 +135,11 @@ IniFile::IniFile(std::filesystem::path const& file_path)
 
     auto const content = std::string_view(file_data.begin(), file_data.end());
     size_t     offset  = 0;
+    size_t     line    = 0;
 
     while (offset < content.size()) {
-        auto const [section_name, section_table] = read_section(content, offset);
-        m_table.emplace(std::string(section_name), section_table);
+        auto const [section_name, section_table] = read_section(content, offset, file_path.string(), line);
+        m_table.emplace(section_name, section_table);
     }
 }
 

--- a/src/libs/config/ini_file.cpp
+++ b/src/libs/config/ini_file.cpp
@@ -31,7 +31,7 @@ std::string get_section_name(std::string_view const& str, std::string const& ini
             "%s:%d: syntax error: no closing bracket (']') - section name ends unexpectedly\n\t%s",
             ini_file_name.c_str(),
             ini_file_line,
-            str.data());
+            std::string(str).data());
         return {};
     }
 
@@ -51,10 +51,9 @@ std::pair<std::string, std::string>
 get_key_value_pair(std::string_view const& str, std::string const& ini_file_name, size_t const ini_file_line)
 {
     auto const key_end = str.find_first_of(KEY_VALUE_SEP);  // Find '=' sign
-    if (key_end == std::string_view::npos) {
-        core->Trace("%s:%d: syntax error: no '=' after key name\n\t%s", ini_file_name.c_str(), ini_file_line, str.data());
-        return std::make_pair(std::string {}, std::string {});
-    }
+    // If there is no value - add key with empty value
+    // In this case key itself acts as a flag, and we're not interested in its value
+    if (key_end == std::string_view::npos) { return std::make_pair(trim(str), std::string {}); }
 
     auto const value_start = key_end + 1;                       // Skip '='
     auto const value_end   = str.find_first_of(KEY_VALUE_END);  // Find comment start (or npos)
@@ -92,7 +91,11 @@ read_section(std::string_view const& str, size_t& offset, std::string const& fil
 
             case INI_SECTION_START:
                 if (!is_section_started) {
-                    section_name       = get_section_name(line, file_name, file_line);
+                    section_name = get_section_name(line, file_name, file_line);
+                    if (section_name.empty()) {  // Parsing error, stop here
+                        is_section_ended = true;
+                        offset           = std::string_view::npos;
+                    }
                     is_section_started = true;  // Section name is parsed, section is started
                 } else {
                     is_section_ended = true;  // If there is another section start, then we're done with current section
@@ -135,12 +138,17 @@ IniFile::IniFile(std::filesystem::path const& file_path)
 
     auto const content = std::string_view(file_data.begin(), file_data.end());
     size_t     offset  = 0;
-    size_t     line    = 0;
+    size_t     line    = 1;
 
     while (offset < content.size()) {
         auto const [section_name, section_table] = read_section(content, offset, file_path.string(), line);
         m_table.emplace(section_name, section_table);
     }
+}
+
+bool IniFile::contains(std::string const& section, std::string const& key) const
+{
+    return m_table.contains(section) && m_table.at(section).contains(key);
 }
 
 std::optional<std::string> IniFile::try_get_string(std::string const& section, std::string const& key) const
@@ -150,7 +158,7 @@ std::optional<std::string> IniFile::try_get_string(std::string const& section, s
     auto const& s           = m_table.at(section);
     auto const [begin, end] = s.equal_range(key);
 
-    return begin->second;
+    return begin->second.empty() ? std::nullopt : std::optional(begin->second);
 }
 
 std::string IniFile::get_string(std::string const& section, std::string const& key) const

--- a/src/libs/config/ini_file.h
+++ b/src/libs/config/ini_file.h
@@ -18,6 +18,8 @@ public:
 
     explicit IniFile(std::filesystem::path const& file_path);
 
+    bool contains(std::string const& section, std::string const& key) const;
+
     std::optional<std::string> try_get_string(std::string const& section, std::string const& key) const;
     std::string                get_string(std::string const& section, std::string const& key) const;
 

--- a/src/libs/config/ini_file.h
+++ b/src/libs/config/ini_file.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "ini_helpers.h"
+
+namespace storm
+{
+
+class IniFile
+{
+public:
+    using Section = std::unordered_multimap<std::string, std::string>;
+
+    explicit IniFile(std::filesystem::path const& file_path);
+
+    std::optional<std::string> try_get_string(std::string const& section, std::string const& key) const;
+    std::string                get_string(std::string const& section, std::string const& key) const;
+
+    std::vector<std::string> get_vector(std::string const& section, std::string const& key) const;
+
+    template <typename T>
+    T find(std::string const& section, std::string const& key) const
+    {
+        return convert_to<T>::from_string(get_string(section, key));
+    }
+
+    template <typename T>
+    T find_or(std::string const& section, std::string const& key, T const& def_value) const
+    {
+        auto const val = try_get_string(section, key);
+        return val.has_value() ? convert_to<T>::from_string(val.value()) : def_value;
+    }
+
+    bool is_empty() const;
+
+    Section const& get_section(std::string const& section) const;
+
+    std::unordered_map<std::string, Section> const& get_sections() const;
+
+private:
+    std::unordered_map<std::string, Section> m_table;
+};
+
+}  // namespace storm

--- a/src/libs/config/ini_helpers.h
+++ b/src/libs/config/ini_helpers.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <stdexcept>
+#include <string>
+
+namespace storm
+{
+class IniFile;
+
+template <typename T>
+struct read_to {
+    static T from_ini([[maybe_unused]] IniFile const& ini, [[maybe_unused]] std::string const& section)
+    {
+        throw std::invalid_argument("Not implemented");
+    }
+};
+
+template <typename T>
+struct convert_to {
+    static T from_string(std::string const& s)
+    {
+        throw std::invalid_argument("Not implemented");
+    }
+};
+
+template <>
+struct convert_to<std::string> {
+    static std::string from_string(std::string const& s)
+    {
+        return s;
+    }
+};
+
+template <>
+struct convert_to<int> {
+    static int from_string(std::string const& s)
+    {
+        return std::stoi(s);
+    }
+};
+
+template <>
+struct convert_to<uint32_t> {
+    static uint32_t from_string(std::string const& s)
+    {
+        return std::stoul(s);
+    }
+};
+
+template <>
+struct convert_to<uint64_t> {
+    static uint64_t from_string(std::string const& s)
+    {
+        return std::stoull(s);
+    }
+};
+
+template <>
+struct convert_to<float> {
+    static float from_string(std::string const& s)
+    {
+        return std::stof(s);
+    }
+};
+
+template <>
+struct convert_to<double> {
+    static double from_string(std::string const& s)
+    {
+        return std::stod(s);
+    }
+};
+
+template <>
+struct convert_to<bool> {
+    static bool from_string(std::string const& s)
+    {
+        return static_cast<bool>(std::stoi(s));
+    }
+};
+
+}  // namespace storm

--- a/src/libs/config/main_config.cpp
+++ b/src/libs/config/main_config.cpp
@@ -4,9 +4,10 @@
 
 #include <libs/core/core.h>
 #include <libs/filesystem/default_paths.h>
-#include <toml.hpp>
 
 #include "i_config_loader.h"
+#include "ini_file.h"
+#include "ini_helpers.h"
 
 using namespace storm;
 
@@ -52,11 +53,11 @@ DeviceInfo const DEFAULT_DEVICE_INFO = {
     .drop_video_conveyor       = false,
 };
 
-SoundInfo const DEFAULT_SOUND_INFO = {
+constexpr SoundInfo DEFAULT_SOUND_INFO = {
     .fade_time_ms = 500,
 };
 
-SeaInfo const DEFAULT_SEA_INFO = {
+constexpr SeaInfo DEFAULT_SEA_INFO = {
     .enable_foam = true,
 };
 
@@ -74,28 +75,28 @@ ScriptInfo const DEFAULT_SCRIPT_INFO = {
     .cache_mode       = 0,
 };
 
-CompatibilityInfo const DEFAULT_COMPATIBILITY_INFO = {
+constexpr CompatibilityInfo DEFAULT_COMPATIBILITY_INFO = {
     .target_version      = ENGINE_VERSION::LATEST,
     .use_lowercase_paths = false,
 };
 
 PathsInfo const DEFAULT_PATHS_INFO = {
-    .resource   = storm::fs::RESOURCE_DIR_DEFAULT,
-    .program    = storm::fs::PROGRAM_DIR_DEFAULT,
-    .config     = storm::fs::CONFIG_DIR_DEFAULT,
-    .aliases    = storm::fs::ALIASES_DIR_DEFAULT,
-    .sounds     = storm::fs::SOUNDS_DIR_DEFAULT,
-    .videos     = storm::fs::VIDEOS_DIR_DEFAULT,
-    .animation  = storm::fs::ANIMATION_DIR_DEFAULT,
-    .models     = storm::fs::MODELS_DIR_DEFAULT,
-    .foam       = storm::fs::FOAM_DIR_DEFAULT,
-    .techniques = storm::fs::TECHNIQUES_DIR_DEFAULT,
-    .particles  = storm::fs::PARTICLES_DIR_DEFAULT,
-    .textures   = storm::fs::TEXTURES_DIR_DEFAULT,
-    .sea        = storm::fs::SEA_DIR_DEFAULT,
+    .resource   = fs::RESOURCE_DIR_DEFAULT,
+    .program    = fs::PROGRAM_DIR_DEFAULT,
+    .ini        = fs::INI_DIR_DEFAULT,
+    .aliases    = fs::ALIASES_DIR_DEFAULT,
+    .sounds     = fs::SOUNDS_DIR_DEFAULT,
+    .videos     = fs::VIDEOS_DIR_DEFAULT,
+    .animation  = fs::ANIMATION_DIR_DEFAULT,
+    .models     = fs::MODELS_DIR_DEFAULT,
+    .foam       = fs::FOAM_DIR_DEFAULT,
+    .techniques = fs::TECHNIQUES_DIR_DEFAULT,
+    .particles  = fs::PARTICLES_DIR_DEFAULT,
+    .textures   = fs::TEXTURES_DIR_DEFAULT,
+    .sea        = fs::SEA_DIR_DEFAULT,
 };
 
-ProgressImageInfo const DEFAULT_PROGRESS_IMAGE_INFO = {
+constexpr ProgressImageInfo DEFAULT_PROGRESS_IMAGE_INFO = {
     .frame           = 0,
     .relative_x      = 0.85F,
     .relative_y      = 0.8F,
@@ -127,243 +128,218 @@ int get_cache_mode_from_string(std::string const& mode)
 
 }  // namespace
 
-namespace toml
-{
-
 template <>
-struct from<storm::GeneralInfo> {
-    static storm::GeneralInfo from_toml(toml::value const& v)
+struct read_to<GeneralInfo> {
+    static GeneralInfo from_ini(IniFile const& ini, std::string const& section)
     {
-        if (!v.is_table()) { return DEFAULT_GENERAL_INFO; }
-
         return {
-            .use_steam   = toml::find_or(v, "steam", DEFAULT_GENERAL_INFO.use_steam),
-            .enable_logs = toml::find_or(v, "logs", DEFAULT_GENERAL_INFO.enable_logs),
+            .use_steam   = ini.find_or(section, "steam", DEFAULT_GENERAL_INFO.use_steam),
+            .enable_logs = ini.find_or(section, "logs", DEFAULT_GENERAL_INFO.enable_logs),
         };
     }
 };
 
 template <>
-struct from<storm::WindowInfo> {
-    static storm::WindowInfo from_toml(toml::value const& v)
+struct read_to<WindowInfo> {
+    static WindowInfo from_ini(IniFile const& ini, std::string const& section)
     {
-        if (!v.is_table()) { return DEFAULT_WINDOW_INFO; }
-
         return {
-            .width               = toml::find_or(v, "width", DEFAULT_WINDOW_INFO.width),
-            .height              = toml::find_or(v, "height", DEFAULT_WINDOW_INFO.height),
-            .preferred_display   = toml::find_or(v, "preferred_display", DEFAULT_WINDOW_INFO.preferred_display),
-            .full_screen         = toml::find_or(v, "full_screen", DEFAULT_WINDOW_INFO.full_screen),
-            .show_borders        = toml::find_or(v, "show_borders", DEFAULT_WINDOW_INFO.show_borders),
-            .run_in_background   = toml::find_or(v, "run_in_background", DEFAULT_WINDOW_INFO.run_in_background),
-            .sound_in_background = toml::find_or(v, "sound_in_background", DEFAULT_WINDOW_INFO.sound_in_background),
-            .vsync               = toml::find_or(v, "vsync", DEFAULT_WINDOW_INFO.vsync),
-            .max_fps             = toml::find_or(v, "max_fps", DEFAULT_WINDOW_INFO.max_fps),
-            .font_config         = toml::find_or(v, "font_config", DEFAULT_WINDOW_INFO.font_config),
-            .font_type           = toml::find_or(v, "font_type", DEFAULT_WINDOW_INFO.font_type),
+            .width               = ini.find_or(section, "width", DEFAULT_WINDOW_INFO.width),
+            .height              = ini.find_or(section, "height", DEFAULT_WINDOW_INFO.height),
+            .preferred_display   = ini.find_or(section, "preferred_display", DEFAULT_WINDOW_INFO.preferred_display),
+            .full_screen         = ini.find_or(section, "full_screen", DEFAULT_WINDOW_INFO.full_screen),
+            .show_borders        = ini.find_or(section, "show_borders", DEFAULT_WINDOW_INFO.show_borders),
+            .run_in_background   = ini.find_or(section, "run_in_background", DEFAULT_WINDOW_INFO.run_in_background),
+            .sound_in_background = ini.find_or(section, "sound_in_background", DEFAULT_WINDOW_INFO.sound_in_background),
+            .vsync               = ini.find_or(section, "vsync", DEFAULT_WINDOW_INFO.vsync),
+            .max_fps             = ini.find_or(section, "max_fps", DEFAULT_WINDOW_INFO.max_fps),
+            .font_config         = ini.find_or(section, "font_config", DEFAULT_WINDOW_INFO.font_config),
+            .font_type           = ini.find_or(section, "font_type", DEFAULT_WINDOW_INFO.font_type),
         };
     }
 };
 
 template <>
-struct from<storm::DeviceInfo> {
-    static storm::DeviceInfo from_toml(toml::value const& v)
+struct read_to<DeviceInfo> {
+    static DeviceInfo from_ini(IniFile const& ini, std::string const& section)
     {
-        if (!v.is_table()) { return DEFAULT_DEVICE_INFO; }
-
-        auto screenshot_ext = toml::find_or(v, "screenshot_ext", DEFAULT_DEVICE_INFO.screenshot_ext);
+        auto screenshot_ext = ini.find_or(section, "screenshot_ext", DEFAULT_DEVICE_INFO.screenshot_ext);
         std::transform(
             screenshot_ext.begin(), screenshot_ext.end(), screenshot_ext.begin(), [](unsigned char const c) { return std::tolower(c); });
 
         return {
-            .adapter                   = toml::find_or(v, "adapter", DEFAULT_DEVICE_INFO.adapter),
-            .msaa_level                = toml::find_or(v, "msaa_level", DEFAULT_DEVICE_INFO.msaa_level),
-            .fov_multiplier            = toml::find_or(v, "fov_multiplier", DEFAULT_DEVICE_INFO.fov_multiplier),
-            .near_clip_plane           = toml::find_or(v, "near_clip_plane", DEFAULT_DEVICE_INFO.near_clip_plane),
-            .far_clip_plane            = toml::find_or(v, "far_clip_plane", DEFAULT_DEVICE_INFO.far_clip_plane),
-            .post_process              = toml::find_or(v, "post_process", DEFAULT_DEVICE_INFO.post_process),
-            .screen_bpp                = toml::find_or(v, "screen_bpp", DEFAULT_DEVICE_INFO.screen_bpp),
-            .screenshot_ext            = toml::find_or(v, "screenshot_ext", DEFAULT_DEVICE_INFO.screenshot_ext),
-            .show_exinfo               = toml::find_or(v, "show_exinfo", DEFAULT_DEVICE_INFO.show_exinfo),
-            .lockable_back_buffer      = toml::find_or(v, "lockable_back_buffer", DEFAULT_DEVICE_INFO.lockable_back_buffer),
-            .use_large_back_buffer     = toml::find_or(v, "use_large_back_buffer", DEFAULT_DEVICE_INFO.use_large_back_buffer),
-            .texture_degradation_level = toml::find_or(v, "texture_degradation_level", DEFAULT_DEVICE_INFO.texture_degradation_level),
-            .show_fps                  = toml::find_or(v, "show_fps", DEFAULT_DEVICE_INFO.show_fps),
-            .safe_rendering            = toml::find_or(v, "safe_rendering", DEFAULT_DEVICE_INFO.safe_rendering),
-            .texture_log               = toml::find_or(v, "texture_log", DEFAULT_DEVICE_INFO.texture_log),
-            .geometry_log              = toml::find_or(v, "geometry_log", DEFAULT_DEVICE_INFO.geometry_log),
-            .drop_video_conveyor       = toml::find_or(v, "drop_video_conveyor", DEFAULT_DEVICE_INFO.drop_video_conveyor),
+            .adapter                   = ini.find_or(section, "adapter", DEFAULT_DEVICE_INFO.adapter),
+            .msaa_level                = ini.find_or(section, "msaa_level", DEFAULT_DEVICE_INFO.msaa_level),
+            .fov_multiplier            = ini.find_or(section, "fov_multiplier", DEFAULT_DEVICE_INFO.fov_multiplier),
+            .near_clip_plane           = ini.find_or(section, "near_clip_plane", DEFAULT_DEVICE_INFO.near_clip_plane),
+            .far_clip_plane            = ini.find_or(section, "far_clip_plane", DEFAULT_DEVICE_INFO.far_clip_plane),
+            .post_process              = ini.find_or(section, "post_process", DEFAULT_DEVICE_INFO.post_process),
+            .screen_bpp                = ini.find_or(section, "screen_bpp", DEFAULT_DEVICE_INFO.screen_bpp),
+            .screenshot_ext            = ini.find_or(section, "screenshot_ext", DEFAULT_DEVICE_INFO.screenshot_ext),
+            .show_exinfo               = ini.find_or(section, "show_exinfo", DEFAULT_DEVICE_INFO.show_exinfo),
+            .lockable_back_buffer      = ini.find_or(section, "lockable_back_buffer", DEFAULT_DEVICE_INFO.lockable_back_buffer),
+            .use_large_back_buffer     = ini.find_or(section, "use_large_back_buffer", DEFAULT_DEVICE_INFO.use_large_back_buffer),
+            .texture_degradation_level = ini.find_or(section, "texture_degradation_level", DEFAULT_DEVICE_INFO.texture_degradation_level),
+            .show_fps                  = ini.find_or(section, "show_fps", DEFAULT_DEVICE_INFO.show_fps),
+            .safe_rendering            = ini.find_or(section, "safe_rendering", DEFAULT_DEVICE_INFO.safe_rendering),
+            .texture_log               = ini.find_or(section, "texture_log", DEFAULT_DEVICE_INFO.texture_log),
+            .geometry_log              = ini.find_or(section, "geometry_log", DEFAULT_DEVICE_INFO.geometry_log),
+            .drop_video_conveyor       = ini.find_or(section, "drop_video_conveyor", DEFAULT_DEVICE_INFO.drop_video_conveyor),
         };
     }
 };
 
 template <>
-struct from<storm::SoundInfo> {
-    static storm::SoundInfo from_toml(toml::value const& v)
+struct read_to<SoundInfo> {
+    static SoundInfo from_ini(IniFile const& ini, std::string const& section)
     {
-        if (!v.is_table()) { return DEFAULT_SOUND_INFO; }
-
         return {
-            .fade_time_ms = toml::find_or(v, "fade_time_ms", DEFAULT_SOUND_INFO.fade_time_ms),
+            .fade_time_ms = ini.find_or(section, "fade_time_ms", DEFAULT_SOUND_INFO.fade_time_ms),
         };
     }
 };
 
 template <>
-struct from<storm::SeaInfo> {
-    static storm::SeaInfo from_toml(toml::value const& v)
+struct read_to<SeaInfo> {
+    static SeaInfo from_ini(IniFile const& ini, std::string const& section)
     {
-        if (!v.is_table()) { return DEFAULT_SEA_INFO; }
-
         return {
-            .enable_foam = toml::find_or(v, "enable_foam", DEFAULT_SEA_INFO.enable_foam),
+            .enable_foam = ini.find_or(section, "enable_foam", DEFAULT_SEA_INFO.enable_foam),
         };
     }
 };
 
 template <>
-struct from<storm::ControlsInfo> {
-    static storm::ControlsInfo from_toml(toml::value const& v)
+struct read_to<ControlsInfo> {
+    static ControlsInfo from_ini(IniFile const& ini, std::string const& section)
     {
-        if (!v.is_table()) { return DEFAULT_CONTROLS_INFO; }
-
         return {
-            .scheme         = toml::find_or(v, "scheme", DEFAULT_CONTROLS_INFO.scheme),
-            .use_debug_keys = toml::find_or(v, "use_debug_keys", DEFAULT_CONTROLS_INFO.use_debug_keys),
+            .scheme         = ini.find_or(section, "scheme", DEFAULT_CONTROLS_INFO.scheme),
+            .use_debug_keys = ini.find_or(section, "use_debug_keys", DEFAULT_CONTROLS_INFO.use_debug_keys),
         };
     }
 };
 
 template <>
-struct from<storm::ScriptInfo> {
-    static storm::ScriptInfo from_toml(toml::value const& v)
+struct read_to<ScriptInfo> {
+    static ScriptInfo from_ini(IniFile const& ini, std::string const& section)
     {
-        if (!v.is_table()) { return DEFAULT_SCRIPT_INFO; }
-
         return {
-            .entry_point      = toml::find<std::string>(v, "entry_point"),
-            .compilation_logs = toml::find_or(v, "compilation_logs", DEFAULT_SCRIPT_INFO.compilation_logs),
-            .create_codefiles = toml::find_or(v, "create_codefiles", DEFAULT_SCRIPT_INFO.create_codefiles),
-            .runtime_logs     = toml::find_or(v, "runtime_logs", DEFAULT_SCRIPT_INFO.runtime_logs),
-            .break_on_error   = toml::find_or(v, "break_on_error", DEFAULT_SCRIPT_INFO.break_on_error),
-            .cache_mode       = get_cache_mode_from_string(toml::find_or<std::string>(v, "cache_mode", "disabled")),
+            .entry_point      = ini.find<std::string>(section, "entry_point"),
+            .compilation_logs = ini.find_or(section, "compilation_logs", DEFAULT_SCRIPT_INFO.compilation_logs),
+            .create_codefiles = ini.find_or(section, "create_codefiles", DEFAULT_SCRIPT_INFO.create_codefiles),
+            .runtime_logs     = ini.find_or(section, "runtime_logs", DEFAULT_SCRIPT_INFO.runtime_logs),
+            .break_on_error   = ini.find_or(section, "break_on_error", DEFAULT_SCRIPT_INFO.break_on_error),
+            .cache_mode       = get_cache_mode_from_string(ini.find_or<std::string>(section, "cache_mode", "disabled")),
         };
     }
 };
 
 template <>
-struct from<storm::CompatibilityInfo> {
-    static storm::CompatibilityInfo from_toml(toml::value const& v)
+struct read_to<CompatibilityInfo> {
+    static CompatibilityInfo from_ini(IniFile const& ini, std::string const& section)
     {
-        if (!v.is_table()) { return DEFAULT_COMPATIBILITY_INFO; }
-
         return {
-            .target_version      = get_engine_version_from_string(toml::find_or<std::string>(v, "target_version", "latest")),
-            .use_lowercase_paths = toml::find_or(v, "use_lowercase_paths", DEFAULT_COMPATIBILITY_INFO.use_lowercase_paths),
+            .target_version      = get_engine_version_from_string(ini.find_or<std::string>(section, "target_version", "latest")),
+            .use_lowercase_paths = ini.find_or(section, "use_lowercase_paths", DEFAULT_COMPATIBILITY_INFO.use_lowercase_paths),
         };
     }
 };
 
 template <>
-struct from<storm::PathsInfo> {
-    static storm::PathsInfo from_toml(toml::value const& v)
+struct read_to<PathsInfo> {
+    static PathsInfo from_ini(IniFile const& ini, std::string const& section)
     {
-        if (!v.is_table()) { return DEFAULT_PATHS_INFO; }
-
         return {
-            .resource   = toml::find_or(v, "resource", DEFAULT_PATHS_INFO.resource.string()),
-            .program    = toml::find_or(v, "program", DEFAULT_PATHS_INFO.program.string()),
-            .config     = toml::find_or(v, "config", DEFAULT_PATHS_INFO.config.string()),
-            .aliases    = toml::find_or(v, "aliases", DEFAULT_PATHS_INFO.aliases.string()),
-            .sounds     = toml::find_or(v, "sounds", DEFAULT_PATHS_INFO.sounds.string()),
-            .videos     = toml::find_or(v, "videos", DEFAULT_PATHS_INFO.videos.string()),
-            .animation  = toml::find_or(v, "animation", DEFAULT_PATHS_INFO.animation.string()),
-            .models     = toml::find_or(v, "models", DEFAULT_PATHS_INFO.models.string()),
-            .foam       = toml::find_or(v, "foam", DEFAULT_PATHS_INFO.foam.string()),
-            .techniques = toml::find_or(v, "techniques", DEFAULT_PATHS_INFO.techniques.string()),
-            .particles  = toml::find_or(v, "particles", DEFAULT_PATHS_INFO.particles.string()),
-            .textures   = toml::find_or(v, "textures", DEFAULT_PATHS_INFO.textures.string()),
-            .sea        = toml::find_or(v, "sea", DEFAULT_PATHS_INFO.sea.string()),
+            .resource   = ini.find_or(section, "resource", DEFAULT_PATHS_INFO.resource.string()),
+            .program    = ini.find_or(section, "program", DEFAULT_PATHS_INFO.program.string()),
+            .ini        = ini.find_or(section, "ini", DEFAULT_PATHS_INFO.ini.string()),
+            .aliases    = ini.find_or(section, "aliases", DEFAULT_PATHS_INFO.aliases.string()),
+            .sounds     = ini.find_or(section, "sounds", DEFAULT_PATHS_INFO.sounds.string()),
+            .videos     = ini.find_or(section, "videos", DEFAULT_PATHS_INFO.videos.string()),
+            .animation  = ini.find_or(section, "animation", DEFAULT_PATHS_INFO.animation.string()),
+            .models     = ini.find_or(section, "models", DEFAULT_PATHS_INFO.models.string()),
+            .foam       = ini.find_or(section, "foam", DEFAULT_PATHS_INFO.foam.string()),
+            .techniques = ini.find_or(section, "techniques", DEFAULT_PATHS_INFO.techniques.string()),
+            .particles  = ini.find_or(section, "particles", DEFAULT_PATHS_INFO.particles.string()),
+            .textures   = ini.find_or(section, "textures", DEFAULT_PATHS_INFO.textures.string()),
+            .sea        = ini.find_or(section, "sea", DEFAULT_PATHS_INFO.sea.string()),
         };
     }
 };
 
 template <>
-struct from<storm::ProgressImageInfo> {
-    static storm::ProgressImageInfo from_toml(toml::value const& v)
+struct read_to<ProgressImageInfo> {
+    static ProgressImageInfo from_ini(IniFile const& ini, std::string const& section)
     {
-        if (!v.is_table()) { return DEFAULT_PROGRESS_IMAGE_INFO; }
-
         return {
-            .frame           = toml::find_or(v, "frame", DEFAULT_PROGRESS_IMAGE_INFO.frame),
-            .relative_x      = toml::find_or(v, "relative_x", DEFAULT_PROGRESS_IMAGE_INFO.relative_x),
-            .relative_y      = toml::find_or(v, "relative_y", DEFAULT_PROGRESS_IMAGE_INFO.relative_y),
-            .relative_width  = toml::find_or(v, "relative_width", DEFAULT_PROGRESS_IMAGE_INFO.relative_width),
-            .relative_height = toml::find_or(v, "relative_height", DEFAULT_PROGRESS_IMAGE_INFO.relative_height),
-            .h_frames_count  = toml::find_or(v, "h_frames_count", DEFAULT_PROGRESS_IMAGE_INFO.h_frames_count),
-            .v_frames_count  = toml::find_or(v, "v_frames_count", DEFAULT_PROGRESS_IMAGE_INFO.v_frames_count),
+            .frame           = ini.find_or(section, "frame", DEFAULT_PROGRESS_IMAGE_INFO.frame),
+            .relative_x      = ini.find_or(section, "relative_x", DEFAULT_PROGRESS_IMAGE_INFO.relative_x),
+            .relative_y      = ini.find_or(section, "relative_y", DEFAULT_PROGRESS_IMAGE_INFO.relative_y),
+            .relative_width  = ini.find_or(section, "relative_width", DEFAULT_PROGRESS_IMAGE_INFO.relative_width),
+            .relative_height = ini.find_or(section, "relative_height", DEFAULT_PROGRESS_IMAGE_INFO.relative_height),
+            .h_frames_count  = ini.find_or(section, "h_frames_count", DEFAULT_PROGRESS_IMAGE_INFO.h_frames_count),
+            .v_frames_count  = ini.find_or(section, "v_frames_count", DEFAULT_PROGRESS_IMAGE_INFO.v_frames_count),
         };
     }
 };
-
-}  // namespace toml
 
 GeneralInfo main_config::general_info()
 {
-    auto const config_file = config_loader->open_config_cached(storm::fs::MAIN_CONFIG_PATH);
-    return toml::get<GeneralInfo>(config_file);
+    auto const& config_file = config_loader->open_config_cached(fs::MAIN_CONFIG_PATH);
+    return read_to<GeneralInfo>::from_ini(config_file, "");
 }
 
 WindowInfo main_config::window_info()
 {
-    auto const config_file = config_loader->open_config_cached(storm::fs::MAIN_CONFIG_PATH);
-    return toml::find_or(config_file, "window", DEFAULT_WINDOW_INFO);
+    auto const& config_file = config_loader->open_config_cached(fs::MAIN_CONFIG_PATH);
+    return read_to<WindowInfo>::from_ini(config_file, "window");
 }
 
 DeviceInfo main_config::device_info()
 {
-    auto const config_file = config_loader->open_config_cached(storm::fs::MAIN_CONFIG_PATH);
-    return toml::find_or(config_file, "device", DEFAULT_DEVICE_INFO);
+    auto const& config_file = config_loader->open_config_cached(fs::MAIN_CONFIG_PATH);
+    return read_to<DeviceInfo>::from_ini(config_file, "device");
 }
 
 SoundInfo main_config::sound_info()
 {
-    auto const config_file = config_loader->open_config_cached(storm::fs::MAIN_CONFIG_PATH);
-    return toml::find_or(config_file, "sound", DEFAULT_SOUND_INFO);
+    auto const& config_file = config_loader->open_config_cached(fs::MAIN_CONFIG_PATH);
+    return read_to<SoundInfo>::from_ini(config_file, "sound");
 }
 
 SeaInfo main_config::sea_info()
 {
-    auto const config_file = config_loader->open_config_cached(storm::fs::MAIN_CONFIG_PATH);
-    return toml::find_or(config_file, "sea", DEFAULT_SEA_INFO);
+    auto const& config_file = config_loader->open_config_cached(fs::MAIN_CONFIG_PATH);
+    return read_to<SeaInfo>::from_ini(config_file, "sea");
 }
 
 ControlsInfo main_config::controls_info()
 {
-    auto const config_file = config_loader->open_config_cached(storm::fs::MAIN_CONFIG_PATH);
-    return toml::find_or(config_file, "controls", DEFAULT_CONTROLS_INFO);
+    auto const& config_file = config_loader->open_config_cached(fs::MAIN_CONFIG_PATH);
+    return read_to<ControlsInfo>::from_ini(config_file, "controls");
 }
 
 ScriptInfo main_config::script_info()
 {
-    auto const config_file = config_loader->open_config_cached(storm::fs::MAIN_CONFIG_PATH);
-    return toml::find_or(config_file, "script", DEFAULT_SCRIPT_INFO);
+    auto const& config_file = config_loader->open_config_cached(fs::MAIN_CONFIG_PATH);
+    return read_to<ScriptInfo>::from_ini(config_file, "script");
 }
 
 CompatibilityInfo main_config::compatibility_info()
 {
-    auto const config_file = config_loader->open_config_cached(storm::fs::MAIN_CONFIG_PATH);
-    return toml::find_or(config_file, "compatibility", DEFAULT_COMPATIBILITY_INFO);
+    auto const& config_file = config_loader->open_config_cached(fs::MAIN_CONFIG_PATH);
+    return read_to<CompatibilityInfo>::from_ini(config_file, "compatibility");
 }
 
 PathsInfo main_config::paths_info()
 {
-    auto const config_file = config_loader->open_config_cached(storm::fs::MAIN_CONFIG_PATH);
-    return toml::find_or(config_file, "paths", DEFAULT_PATHS_INFO);
+    auto const& config_file = config_loader->open_config_cached(fs::MAIN_CONFIG_PATH);
+    return read_to<PathsInfo>::from_ini(config_file, "paths");
 }
 
 ProgressImageInfo main_config::progress_image_info()
 {
-    auto const config_file = config_loader->open_config_cached(storm::fs::MAIN_CONFIG_PATH);
-    return toml::find_or(config_file, "progress_image_info", DEFAULT_PROGRESS_IMAGE_INFO);
+    auto const& config_file = config_loader->open_config_cached(fs::MAIN_CONFIG_PATH);
+    return read_to<ProgressImageInfo>::from_ini(config_file, "progress_image_info");
 }

--- a/src/libs/config/main_config.h
+++ b/src/libs/config/main_config.h
@@ -77,7 +77,7 @@ struct CompatibilityInfo {
 struct PathsInfo {
     std::filesystem::path resource;
     std::filesystem::path program;
-    std::filesystem::path config;
+    std::filesystem::path ini;
     std::filesystem::path aliases;
     std::filesystem::path sounds;
     std::filesystem::path videos;

--- a/src/libs/config/sound_alias.cpp
+++ b/src/libs/config/sound_alias.cpp
@@ -1,9 +1,12 @@
 #include "sound_alias.h"
 
+#include <ranges>
+
 #include <libs/core/core.h>
-#include <toml.hpp>
 
 #include "i_config_loader.h"
+#include "ini_file.h"
+#include "ini_helpers.h"
 
 using namespace storm;
 
@@ -14,50 +17,45 @@ constexpr float DEFAULT_PROBABILITY = 1.0F;
 
 }  // namespace
 
-namespace toml
-{
-
 template <>
-struct from<storm::SoundAlias> {
-    static storm::SoundAlias from_toml(toml::value const& v)
+struct read_to<SoundAlias> {
+    static SoundAlias from_ini(IniFile const& ini, std::string const& section)
     {
-        // No sound_files - no alias
-        if (!v.is_table() || !v.contains("sound_files") || !v.at("sound_files").is_array()) { return {}; }
+        ProbabilityTable<std::string> files = {};
 
-        storm::ProbabilityTable<std::string> files = {};
-        for (auto const& file: v.at("sound_files").as_array()) {
-            if (!file.is_table() || !file.contains("name")) { return {}; }
+        // TODO: syntax check
+        auto [name_begin, name_end] = ini.get_section(section).equal_range("name");
+        std::for_each(name_begin, name_end, [&](std::pair<std::string, std::string> const& pair) {
+            auto const& [_, name] = pair;
+            // Check if it's just name or name with probability separated by comma
+            auto const comma = name.find_first_of(',');
 
-            auto const probability = toml::find_or(file, "probability", DEFAULT_PROBABILITY);
-            auto const name        = toml::find_or<std::string>(file, "name", "");
+            try {
+                float const       probability = comma == std::string::npos ? DEFAULT_PROBABILITY : std::stof(name.substr(comma + 1));
+                std::string const file_name   = comma == std::string::npos ? name : name.substr(0, comma);
 
-            if (name.empty()) { continue; }
-
-            files.emplace(probability, name);
-        }
+                files.emplace(probability, file_name);
+            } catch (std::invalid_argument const& e) {
+                core->Trace("IniFile::read_to<SoundAlias>() can't parse section \"%s\", name value \"%s\"", section.c_str(), name.c_str());
+            }
+        });
 
         return {
-            .min_distance = toml::find_or(v, "min_distance", -1.0F),
-            .max_distance = toml::find_or(v, "max_distance", -1.0F),
-            .volume       = toml::find_or(v, "volume", -1.0F),
+            .min_distance = ini.find_or(section, "minDistance", -1.0F),
+            .max_distance = ini.find_or(section, "maxDistance", -1.0F),
+            .volume       = ini.find_or(section, "volume", -1.0F),
             .files        = std::move(files),
         };
     }
 };
 
-}  // namespace toml
-
 std::unordered_map<std::string, SoundAlias> sound_alias::aliases(std::filesystem::path const& file)
 {
-    auto const config_file = config_loader->open_config_cached(file);
-    if (!config_file.is_table()) {
-        core->Trace("There are no aliases in file \"%s\"", file.string().c_str());
-        return {};
-    }
+    auto const& config_file = config_loader->open_config_cached(file);
 
     std::unordered_map<std::string, SoundAlias> aliases = {};
-    for (auto const& [name, value]: config_file.as_table()) {
-        aliases.emplace(name, toml::get<SoundAlias>(value));
+    for (auto const& name: config_file.get_sections() | std::views::keys) {
+        aliases.emplace(name, read_to<SoundAlias>::from_ini(config_file, name));
     }
 
     return aliases;

--- a/src/libs/dialog/dialog.cpp
+++ b/src/libs/dialog/dialog.cpp
@@ -458,9 +458,9 @@ void Dialog::DrawButtons()
 void Dialog::LoadFromIni()
 {
     // FIXME: hardcode
-    auto pIni = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Config) / "dialog.ini");
+    auto pIni = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Ini) / "dialog.ini");
     if (!pIni) {
-        core->Trace("Warning! DIALOG: Can`t open ini file %s/dialog.ini", fio->base_directory_path(BaseDirectory::Config).string().c_str());
+        core->Trace("Warning! DIALOG: Can`t open ini file %s/dialog.ini", fio->base_directory_path(BaseDirectory::Ini).string().c_str());
         return;
     }
 
@@ -592,7 +592,7 @@ bool Dialog::Init()
     textViewport.MaxZ   = 1.0f;
 
     // FIXME: hardcode
-    auto ini = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Config) / "dialog.ini");
+    auto ini = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Ini) / "dialog.ini");
     m_DlgText.Init(RenderService, textViewport, ini.get());
     InitLinks(RenderService, textViewport, ini.get());
 

--- a/src/libs/dialog/legacy_dialog.cpp
+++ b/src/libs/dialog/legacy_dialog.cpp
@@ -277,7 +277,7 @@ uint64_t LegacyDialog::ProcessMessage(MESSAGE& msg)
 
 void LegacyDialog::LoadIni()
 {
-    auto ini = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Config) / DIALOG_INI_FILE_PATH);
+    auto ini = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Ini) / DIALOG_INI_FILE_PATH);
 
     mainFont_ = LoadFont("mainfont", *ini, *RenderService);
     nameFont_ = LoadFont("namefont", *ini, *RenderService);

--- a/src/libs/filesystem/default_paths.h
+++ b/src/libs/filesystem/default_paths.h
@@ -7,8 +7,8 @@ namespace storm::fs
 
 static inline auto const RESOURCE_DIR_DEFAULT   = std::filesystem::path() / "resource";
 static inline auto const PROGRAM_DIR_DEFAULT    = std::filesystem::path() / "program";
-static inline auto const CONFIG_DIR_DEFAULT     = RESOURCE_DIR_DEFAULT / "ini";
-static inline auto const ALIASES_DIR_DEFAULT    = CONFIG_DIR_DEFAULT / "aliases";
+static inline auto const INI_DIR_DEFAULT        = RESOURCE_DIR_DEFAULT / "ini";
+static inline auto const ALIASES_DIR_DEFAULT    = INI_DIR_DEFAULT / "aliases";
 static inline auto const SOUNDS_DIR_DEFAULT     = RESOURCE_DIR_DEFAULT / "sounds";
 static inline auto const VIDEOS_DIR_DEFAULT     = RESOURCE_DIR_DEFAULT / "videos";
 static inline auto const ANIMATION_DIR_DEFAULT  = RESOURCE_DIR_DEFAULT / "animation";
@@ -19,6 +19,6 @@ static inline auto const PARTICLES_DIR_DEFAULT  = RESOURCE_DIR_DEFAULT / "partic
 static inline auto const TEXTURES_DIR_DEFAULT   = RESOURCE_DIR_DEFAULT / "textures";
 static inline auto const SEA_DIR_DEFAULT        = RESOURCE_DIR_DEFAULT / "sea";
 
-static inline auto const MAIN_CONFIG_PATH = std::filesystem::path() / "engine.toml";
+static inline auto const MAIN_CONFIG_PATH = std::filesystem::path() / "engine.ini";
 
 }  // namespace storm::fs

--- a/src/libs/filesystem/file_service.cpp
+++ b/src/libs/filesystem/file_service.cpp
@@ -73,7 +73,7 @@ FileService::FileService()
 
     m_paths.resource   = storm::fs::RESOURCE_DIR_DEFAULT;
     m_paths.program    = storm::fs::PROGRAM_DIR_DEFAULT;
-    m_paths.config     = storm::fs::CONFIG_DIR_DEFAULT;
+    m_paths.ini        = storm::fs::INI_DIR_DEFAULT;
     m_paths.aliases    = storm::fs::ALIASES_DIR_DEFAULT;
     m_paths.sounds     = storm::fs::SOUNDS_DIR_DEFAULT;
     m_paths.videos     = storm::fs::VIDEOS_DIR_DEFAULT;
@@ -318,7 +318,7 @@ std::filesystem::path FileService::base_directory_path(BaseDirectory dir)
     switch (dir) {
     case BaseDirectory::Resource: return m_paths.resource;
     case BaseDirectory::Program: return m_paths.program;
-    case BaseDirectory::Config: return m_paths.config;
+    case BaseDirectory::Ini: return m_paths.ini;
     case BaseDirectory::Aliases: return m_paths.aliases;
     case BaseDirectory::Sounds: return m_paths.sounds;
     case BaseDirectory::Videos: return m_paths.videos;

--- a/src/libs/filesystem/v_file_service.h
+++ b/src/libs/filesystem/v_file_service.h
@@ -12,7 +12,7 @@ enum class BaseDirectory {
     None,
     Resource,
     Program,
-    Config,
+    Ini,
     Aliases,
     Sounds,
     Videos,

--- a/src/libs/filesystem/v_file_service.h
+++ b/src/libs/filesystem/v_file_service.h
@@ -69,9 +69,9 @@ public:
     virtual void init_from_main_config() = 0;
 
     // ini files section
-    [[deprecated("Ini config files are deprecated, rewrite configs for TOML parser in libs/config")]] virtual std::unique_ptr<INIFILE>
+    [[deprecated("Rewrite config parsing on new parser in libs/config")]] virtual std::unique_ptr<INIFILE>
     create_ini_file(std::filesystem::path const& file, bool fail_if_exist) = 0;
-    [[deprecated("Ini config files are deprecated, rewrite configs for TOML parser in libs/config")]] virtual std::unique_ptr<INIFILE>
+    [[deprecated("Rewrite config parsing on new parser in libs/config")]] virtual std::unique_ptr<INIFILE>
     open_ini_file(std::filesystem::path const& file) = 0;
 
     virtual uint64_t path_fingerprint(std::filesystem::path const& path) = 0;

--- a/src/libs/geometry/geometry.cpp
+++ b/src/libs/geometry/geometry.cpp
@@ -328,7 +328,7 @@ void GEOM_SERVICE_R::ReleaseVertexBuffer(GEOS::ID vb)
     if (vb == INVALID_BUFFER_ID) return;
     if (RenderService)
         if (vb >= SHIFT_VALUE) {
-            delete static_cast<char*>(avb[vb - SHIFT_VALUE].buff);
+            delete[] static_cast<char*>(avb[vb - SHIFT_VALUE].buff);
             avb[vb - SHIFT_VALUE].nvertices = 0;
         } else
             RenderService->ReleaseVertexBuffer(vb);

--- a/src/libs/lighter/lighter.cpp
+++ b/src/libs/lighter/lighter.cpp
@@ -34,7 +34,7 @@ bool Lighter::Init()
 {
     // Checking if ini file exists
     // FIXME: hardcode
-    auto ini = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Config) / "loclighter.ini");
+    auto ini = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Ini) / "loclighter.ini");
     if (!ini) return false;
     auto const isLoading = ini->GetInt(nullptr, "loading", 0);
     autoTrace            = ini->GetInt(nullptr, "autotrace", 0) != 0;

--- a/src/libs/lighter/window.cpp
+++ b/src/libs/lighter/window.cpp
@@ -958,7 +958,7 @@ int32_t Window::SelPreset()
         if (lastPreset != ins) {
             // Load the name
             // FIXME: hardcode
-            auto ini = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Config) / "loclighter.ini");
+            auto ini = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Ini) / "loclighter.ini");
             if (ini) {
                 char sect[32];
                 sprintf_s(sect, "prs%i", ins);
@@ -980,7 +980,7 @@ void Window::SavePreset(int32_t prs)
     if (prs < 0) return;
     // Checking if able to work
     // FIXME: hardcode
-    auto ini = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Config) / "loclighter.ini");
+    auto ini = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Ini) / "loclighter.ini");
     if (!ini) return;
     char sect[32];
     sprintf_s(sect, "prs%i", prs);
@@ -1041,7 +1041,7 @@ void Window::LoadPreset(int32_t prs)
     if (prs < 0) return;
     // Checking if able to work
     // FIXME: hardcode
-    auto ini = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Config) / "loclighter.ini");
+    auto ini = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Ini) / "loclighter.ini");
     if (!ini) return;
     char sect[32];
     sprintf_s(sect, "prs%i", prs);

--- a/src/libs/location/character.cpp
+++ b/src/libs/location/character.cpp
@@ -122,7 +122,7 @@ Character::ActionCharacter::ActionCharacter()
 
 void Character::ActionCharacter::SetName(char const* _name)
 {
-    if (name) delete name;
+    if (name) delete[] name;
     name = nullptr;
     if (_name && _name[0]) {
         int32_t const l = strlen(_name) + 1;
@@ -139,7 +139,7 @@ void Character::ActionCharacter::ChangeName(char const* _name)
 
 Character::ActionCharacter::~ActionCharacter()
 {
-    if (name) delete name;
+    if (name) delete[] name;
     name = nullptr;
 }
 
@@ -590,6 +590,15 @@ Character::Character()
     headLookPointTarget = 0.0f;
     curHeadAX           = 0.0f;
     curHeadAY           = 0.0f;
+
+    enemyAttack = {};
+    mdl         = {};
+    shadow      = {};
+    blade       = {};
+    sea         = {};
+    effects     = {};
+    sign        = {};
+    waterrings  = {};
 }
 
 Character::~Character()
@@ -623,7 +632,7 @@ Character::~Character()
     core->EraseEntity(mdl);
     core->EraseEntity(blade);
     core->EraseEntity(sign);
-    delete characterID;
+    delete[] characterID;
 }
 
 // Initialization

--- a/src/libs/location/characters_groups.cpp
+++ b/src/libs/location/characters_groups.cpp
@@ -42,7 +42,7 @@ CharactersGroups::~CharactersGroups()
 {
     for (int32_t i = 0; i < maxGroups; i++) {
         if (groups[i]) {
-            if (groups[i]->relations) delete groups[i]->relations;
+            if (groups[i]->relations) delete[] groups[i]->relations;
             delete groups[i];
         }
     }
@@ -67,7 +67,7 @@ CharactersGroups::String::String(char const* str)
 
 CharactersGroups::String::~String()
 {
-    if (name) delete name;
+    if (name) delete[] name;
 }
 
 void CharactersGroups::String::operator=(char const* str)
@@ -79,7 +79,7 @@ void CharactersGroups::String::operator=(char const* str)
     } else {
         len = strlen(str);
         if (len + 1 > max) {
-            if (name) delete name;
+            if (name) delete[] name;
             max  = (len + 16) & ~15;
             name = new char[max];
         }

--- a/src/libs/location/lights.cpp
+++ b/src/libs/location/lights.cpp
@@ -55,10 +55,10 @@ bool Lights::Init()
     collide = static_cast<COLLIDE*>(core->GetService("CollideService"));
     // read the parameters
     // FIXME: hardcode
-    auto ini = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Config) / "lights.ini");
+    auto ini = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Ini) / "lights.ini");
     if (!ini) {
         core->Trace(
-            "Location lights not inited -> %s/lights.ini not found", fio->base_directory_path(BaseDirectory::Config).string().c_str());
+            "Location lights not inited -> %s/lights.ini not found", fio->base_directory_path(BaseDirectory::Ini).string().c_str());
         return false;
     }
     char lName[256];
@@ -468,7 +468,7 @@ void Lights::UnsetLights()
 void Lights::UpdateLightTypes(int32_t i)
 {
     // FIXME: hardcode
-    auto ini = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Config) / "lights.ini");
+    auto ini = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Ini) / "lights.ini");
     if (!ini) return;
     // Source name
     char* lName = types[i].name;

--- a/src/libs/location/lights.cpp
+++ b/src/libs/location/lights.cpp
@@ -39,7 +39,7 @@ Lights::~Lights()
 {
     for (int32_t i = 0; i < numTypes; i++) {
         if (types[i].corona >= 0 && rs) rs->TextureRelease(types[i].corona);
-        delete types[i].name;
+        delete[] types[i].name;
     }
     if (rs)
         for (int32_t i = 1; i < 8; i++)
@@ -57,8 +57,7 @@ bool Lights::Init()
     // FIXME: hardcode
     auto ini = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Ini) / "lights.ini");
     if (!ini) {
-        core->Trace(
-            "Location lights not inited -> %s/lights.ini not found", fio->base_directory_path(BaseDirectory::Ini).string().c_str());
+        core->Trace("Location lights not inited -> %s/lights.ini not found", fio->base_directory_path(BaseDirectory::Ini).string().c_str());
         return false;
     }
     char lName[256];

--- a/src/libs/location/location.cpp
+++ b/src/libs/location/location.cpp
@@ -57,6 +57,16 @@ Location::Location()
     bDrawBars          = true;
     bSwimming          = true;
     bCausticEnable     = false;
+
+    grass        = {};
+    eagle        = {};
+    lizards      = {};
+    rats         = {};
+    crabs        = {};
+    blood        = {};
+    lightsid     = {};
+    loceffectsid = {};
+    lighter      = {};
 }
 
 Location::~Location()

--- a/src/libs/location/locator_array.cpp
+++ b/src/libs/location/locator_array.cpp
@@ -37,7 +37,7 @@ LocatorArray::LocatorArray(char const* groupName)
 
 LocatorArray::~LocatorArray()
 {
-    delete group;
+    delete[] group;
     free(locatorNames);
 }
 

--- a/src/libs/locator/blast.cpp
+++ b/src/libs/locator/blast.cpp
@@ -31,9 +31,9 @@ bool Blast::Init()
 
     //    int32_t n;
     // FIXME: hardcode
-    auto ini = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Config) / "particles" / "particles.ini");
+    auto ini = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Ini) / "particles" / "particles.ini");
     if (!ini) {
-        core->Trace("not found: %s/particles/particles.ini", fio->base_directory_path(BaseDirectory::Config).string().c_str());
+        core->Trace("not found: %s/particles/particles.ini", fio->base_directory_path(BaseDirectory::Ini).string().c_str());
         return false;
     }
 

--- a/src/libs/mast/mast.cpp
+++ b/src/libs/mast/mast.cpp
@@ -98,8 +98,8 @@ void Mast::Execute(uint32_t Delta_Time)
     if (bUse) {
         // ====================================================
         // If the ini-file has been changed, read the info from it
-        if (fio->exists(fio->base_directory_path(BaseDirectory::Config) / MAST_INI_FILE)) {
-            auto ft_new = fio->last_write_time(fio->base_directory_path(BaseDirectory::Config) / MAST_INI_FILE);
+        if (fio->exists(fio->base_directory_path(BaseDirectory::Ini) / MAST_INI_FILE)) {
+            auto ft_new = fio->last_write_time(fio->base_directory_path(BaseDirectory::Ini) / MAST_INI_FILE);
             if (ft_old != ft_new) { LoadIni(); }
         }
         doMove(Delta_Time);
@@ -361,10 +361,10 @@ void Mast::LoadIni()
     // GUARD(MAST::LoadIni());
     char section[256];
 
-    if (fio->exists(fio->base_directory_path(BaseDirectory::Config) / MAST_INI_FILE)) {
-        ft_old = fio->last_write_time(fio->base_directory_path(BaseDirectory::Config) / MAST_INI_FILE);
+    if (fio->exists(fio->base_directory_path(BaseDirectory::Ini) / MAST_INI_FILE)) {
+        ft_old = fio->last_write_time(fio->base_directory_path(BaseDirectory::Ini) / MAST_INI_FILE);
     }
-    auto ini = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Config) / MAST_INI_FILE);
+    auto ini = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Ini) / MAST_INI_FILE);
     if (!ini) { throw std::runtime_error("mast.ini file not found!"); }
 
     sprintf_s(section, "MAST");

--- a/src/libs/renderer/s_device.cpp
+++ b/src/libs/renderer/s_device.cpp
@@ -499,7 +499,7 @@ bool RendererService::Init()
     auto font_config = window_info.font_config;
     // get start ini file for fonts
     if (font_config.empty()) {
-        core->Trace("Not found 'font_config' parameter in engine.toml file (must be in 'window' section)");
+        core->Trace("Not found 'font_config' parameter in engine.ini file (must be in 'window' section)");
         font_config = (fio->base_directory_path(BaseDirectory::Ini) / "fonts.ini").string();
     }
 

--- a/src/libs/renderer/s_device.cpp
+++ b/src/libs/renderer/s_device.cpp
@@ -500,7 +500,7 @@ bool RendererService::Init()
     // get start ini file for fonts
     if (font_config.empty()) {
         core->Trace("Not found 'font_config' parameter in engine.toml file (must be in 'window' section)");
-        font_config = (fio->base_directory_path(BaseDirectory::Config) / "fonts.ini").string();
+        font_config = (fio->base_directory_path(BaseDirectory::Ini) / "fonts.ini").string();
     }
 
     auto const len = font_config.size() + 1;

--- a/src/libs/renderer/s_device.cpp
+++ b/src/libs/renderer/s_device.cpp
@@ -1181,7 +1181,7 @@ int32_t RendererService::TextureCreate(char const* fname)
     if (!bLoadTextureEnabled) return -1;
 
     for (int32_t i = 3; i >= -1; i--) {
-        char _fname[256];
+        char _fname[256] = {};
 
         if (i >= 0 && TexPaths[i].str[0] == 0) continue;
         if (i >= 0) {
@@ -1202,7 +1202,7 @@ int32_t RendererService::TextureCreate(char const* fname)
             strcpy_s(_fname, fname);
         }
 
-        std::ranges::for_each(_fname, [](char& c) { c = std::tolower(c); });
+        std::ranges::transform(_fname, _fname, [](unsigned char const c) { return std::tolower(c); });
 
         uint32_t const hf = case_insensitive_hash(_fname);
 
@@ -2522,7 +2522,7 @@ int32_t RendererService::ExtPrint(
 int32_t RendererService::LoadFont(char const* fontName)
 {
     if (fontName == nullptr) return -1L;
-    char sDup[256];
+    char sDup[256] = {};
     if (strlen(fontName) < sizeof(sDup) - 1)
         strcpy_s(sDup, fontName);
     else {
@@ -2530,7 +2530,7 @@ int32_t RendererService::LoadFont(char const* fontName)
         sDup[sizeof(sDup) - 1] = 0;
     }
 
-    std::ranges::for_each(sDup, [](char& c) { c = std::toupper(c); });
+    std::ranges::transform(sDup, sDup, [](unsigned char const c) { return std::tolower(c); });
     fontName = sDup;
 
     uint32_t const hashVal = case_insensitive_hash(fontName);

--- a/src/libs/renderer/technique.cpp
+++ b/src/libs/renderer/technique.cpp
@@ -1686,15 +1686,19 @@ void CTechnique::DecodeFiles(char* sub_dir)
 
     InnerDecodeFiles(sub_dir);
 
-    STORM_DELETE(pPassStorage);
+    delete[] pPassStorage;
+    pPassStorage = nullptr;
+
     RDTSC_E(dwRDTSC);
     core->Trace("Techniques: %d shaders compiled.", dwNumShaders);
     core->Trace("Techniques: %d techniques compiled.", dwNumBlocks);
     core->Trace("Techniques: compiled by %d ticks.", dwRDTSC);
 
     // some optimize
-    for (uint32_t i = 0; i < dwNumBlocks; i++)
-        STORM_DELETE(pBlocks[i].pBlockName);
+    for (uint32_t i = 0; i < dwNumBlocks; i++) {
+        delete[] pBlocks[i].pBlockName;
+        pBlocks[i].pBlockName = nullptr;
+    }
 }
 
 void CTechnique::InnerDecodeFiles(char* sub_dir)
@@ -1759,7 +1763,7 @@ bool CTechnique::DecodeFile(std::string sname)
         SKIP;
     }
 
-    STORM_DELETE(pFile);
+    delete[] pFile;
     return true;
 }
 

--- a/src/libs/rigging/flag.cpp
+++ b/src/libs/rigging/flag.cpp
@@ -32,7 +32,9 @@ Flag::Flag()
 Flag::~Flag()
 {
     TEXTURE_RELEASE(RenderService, texl);
-    STORM_DELETE(gdata);
+    delete[] gdata;
+    gdata = nullptr;
+
     VERTEX_BUFFER_RELEASE(RenderService, vBuf);
     INDEX_BUFFER_RELEASE(RenderService, iBuf);
 
@@ -40,7 +42,9 @@ Flag::~Flag()
         flagQuantity--;
         STORM_DELETE(flist[flagQuantity]);
     }
-    STORM_DELETE(flist);
+
+    delete[] flist;
+    flist = nullptr;
 }
 
 bool Flag::Init()
@@ -154,7 +158,7 @@ uint64_t Flag::ProcessMessage(MESSAGE& message)
             auto* const oldgdata = gdata;
             gdata                = new GROUPDATA[groupQuantity + 1];
             memcpy(gdata, oldgdata, sizeof(GROUPDATA) * groupQuantity);
-            delete oldgdata;
+            delete[] oldgdata;
             groupQuantity++;
         }
         gdata[groupQuantity - 1].model_id = eidModel;

--- a/src/libs/rigging/flag.cpp
+++ b/src/libs/rigging/flag.cpp
@@ -84,7 +84,7 @@ void Flag::Execute(uint32_t Delta_Time)
     if (bUse) {
         // ====================================================
         // If the ini-file has been changed, read the info from it
-        auto const file_path = fio->base_directory_path(BaseDirectory::Config) / RIGGING_INI_FILE;
+        auto const file_path = fio->base_directory_path(BaseDirectory::Ini) / RIGGING_INI_FILE;
         if (fio->exists(file_path)) {
             auto ft_new = fio->last_write_time(file_path);
             if (ft_old != ft_new) { LoadIni(); }
@@ -498,7 +498,7 @@ void Flag::LoadIni()
     char section[256];
     char param[256];
 
-    auto const file_path = fio->base_directory_path(BaseDirectory::Config) / RIGGING_INI_FILE;
+    auto const file_path = fio->base_directory_path(BaseDirectory::Ini) / RIGGING_INI_FILE;
     if (fio->exists(file_path)) { ft_old = fio->last_write_time(file_path); }
     auto ini = fio->open_ini_file(file_path);
     if (!ini) { throw std::runtime_error("rigging.ini file not found!"); }

--- a/src/libs/rigging/rope.cpp
+++ b/src/libs/rigging/rope.cpp
@@ -681,7 +681,7 @@ void Rope::LoadIni()
     char param[256];
 
     // FIXME: hardcode
-    auto ini = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Config) / "rigging.ini");
+    auto ini = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Ini) / "rigging.ini");
     if (!ini) throw std::runtime_error("rigging.ini file not found!");
 
     sprintf_s(section, "ROPES");

--- a/src/libs/rigging/rope.cpp
+++ b/src/libs/rigging/rope.cpp
@@ -38,22 +38,28 @@ Rope::Rope()
 Rope::~Rope()
 {
     // clearing and deleting the rope list
-    if (rlist) {
+    if (rlist != nullptr) {
         for (auto i = 0; i < ropeQuantity; i++)
             STORM_DELETE(rlist[i]);
-        STORM_DELETE(rlist);
+        delete[] rlist;
+        rlist = nullptr;
+
         ropeQuantity = 0;
     }
     // clearing and deleting the group list
-    if (gdata) {
-        for (auto i = 0; i < groupQuantity; i++)
-            STORM_DELETE(gdata[i].ropeIdx);
-        STORM_DELETE(gdata);
+    if (gdata != nullptr) {
+        for (auto i = 0; i < groupQuantity; i++) {
+            delete[] gdata[i].ropeIdx;
+        }
+        delete[] gdata;
+        gdata = nullptr;
+
         groupQuantity = 0;
     }
     // removing textures
     TEXTURE_RELEASE(RenderService, texl);
-    STORM_DELETE(TextureName);
+    delete[] TextureName;
+    TextureName = nullptr;
 
     VERTEX_BUFFER_RELEASE(RenderService, vBuf);
     INDEX_BUFFER_RELEASE(RenderService, iBuf);
@@ -188,7 +194,7 @@ uint64_t Rope::ProcessMessage(MESSAGE& message)
             gdata                = new GROUPDATA[groupQuantity + 1];
             if (gdata == nullptr) { throw std::runtime_error("allocate memory error"); }
             memcpy(gdata, oldgdata, sizeof(GROUPDATA) * groupQuantity);
-            delete oldgdata;
+            delete[] oldgdata;
             groupQuantity++;
         } else {
             gdata         = new GROUPDATA[1];

--- a/src/libs/rigging/sail.cpp
+++ b/src/libs/rigging/sail.cpp
@@ -294,7 +294,7 @@ void Sail::Execute(uint32_t Delta_Time)
         int i;
         // ====================================================
         // If the ini-file has been changed, read the info from it
-        auto const file_path = fio->base_directory_path(BaseDirectory::Config) / RIGGING_INI_FILE;
+        auto const file_path = fio->base_directory_path(BaseDirectory::Ini) / RIGGING_INI_FILE;
         if (fio->exists(file_path)) {
             auto ft_new = fio->last_write_time(file_path);
             if (ft_old != ft_new) {
@@ -1146,7 +1146,7 @@ void Sail::LoadSailIni()
     // GUARD(SAIL::LoadSailIni());
     char section[256], param[256];
 
-    auto const file_path = fio->base_directory_path(BaseDirectory::Config) / RIGGING_INI_FILE;
+    auto const file_path = fio->base_directory_path(BaseDirectory::Ini) / RIGGING_INI_FILE;
     if (fio->exists(file_path)) { ft_old = fio->last_write_time(file_path); }
     auto ini = fio->open_ini_file(file_path);
     if (!ini) { throw std::runtime_error("rigging.ini file not found!"); }

--- a/src/libs/rigging/sail.cpp
+++ b/src/libs/rigging/sail.cpp
@@ -178,13 +178,14 @@ Sail::~Sail()
     if (slist != nullptr) {
         for (auto i = 0; i < sailQuantity; i++)
             STORM_DELETE(slist[i]);
-        STORM_DELETE(slist);
+        delete[] slist;
+        slist = nullptr;
     }
     if (gdata != nullptr) {
         for (auto i = 0; i < groupQuantity; i++) {
-            STORM_DELETE(gdata[i].sailIdx);
+            delete[] gdata[i].sailIdx;
         }
-        delete (char*)gdata;
+        delete[] gdata;
         gdata = nullptr;
     }
 
@@ -192,9 +193,12 @@ Sail::~Sail()
     INDEX_BUFFER_RELEASE(RenderService, sg.indxBuf);
     TEXTURE_RELEASE(RenderService, texl);
     TEXTURE_RELEASE(RenderService, m_nEmptyGerbTex);
-    STORM_DELETE(WindVect);
+    delete[] WindVect;
+    WindVect = nullptr;
+
     m_nMastCreatedCharacter = -1;
-    STORM_DELETE(m_sMastName);
+    delete[] m_sMastName;
+    m_sMastName = nullptr;
 }
 
 bool Sail::Init()
@@ -595,7 +599,7 @@ uint64_t Sail::ProcessMessage(MESSAGE& message)
             GROUPDATA* oldgdata = gdata;
             gdata               = new GROUPDATA[groupQuantity + 1];
             memcpy(gdata, oldgdata, sizeof(GROUPDATA) * groupQuantity);
-            delete oldgdata;
+            delete[] oldgdata;
             oldgdata = nullptr;
             groupQuantity++;
         } else {
@@ -859,7 +863,9 @@ uint64_t Sail::ProcessMessage(MESSAGE& message)
 
         // start / end attaching sails to the drop mast
     case MSG_SAIL_MAST_PROCESSING:
-        STORM_DELETE(m_sMastName);
+        delete[] m_sMastName;
+        m_sMastName = nullptr;
+
         m_nMastCreatedCharacter = message.Long();
         if (m_nMastCreatedCharacter != -1) {
             std::string const& param = message.String();
@@ -1071,12 +1077,12 @@ void Sail::SetAllSails(int groupNum)
             gdata               = new GROUPDATA[groupQuantity];
             if (gdata) {
                 memcpy(gdata, oldgdata, sizeof(GROUPDATA) * groupQuantity);
-                delete oldgdata;
+                delete[] oldgdata;
                 oldgdata = nullptr;
             } else
                 gdata = oldgdata;
         } else {
-            delete gdata;
+            delete[] gdata;
             gdata = nullptr;
         }
     }

--- a/src/libs/rigging/vant.cpp
+++ b/src/libs/rigging/vant.cpp
@@ -83,7 +83,7 @@ void VANT_BASE::Execute(uint32_t Delta_Time)
     if (bUse) {
         // ====================================================
         // If the ini-file has been changed, read the info from it
-        auto const file_path = fio->base_directory_path(BaseDirectory::Config) / RIGGING_INI_FILE;
+        auto const file_path = fio->base_directory_path(BaseDirectory::Ini) / RIGGING_INI_FILE;
         if (fio->exists(file_path)) {
             auto ft_new = fio->last_write_time(file_path);
             if (ft_old != ft_new) { LoadIni(); }
@@ -544,7 +544,7 @@ void Vant::LoadIni()
     char section[256];
     char param[256];
 
-    auto const file_path = fio->base_directory_path(BaseDirectory::Config) / RIGGING_INI_FILE;
+    auto const file_path = fio->base_directory_path(BaseDirectory::Ini) / RIGGING_INI_FILE;
     if (fio->exists(file_path)) { ft_old = fio->last_write_time(file_path); }
     auto ini = fio->open_ini_file(file_path);
     if (!ini) { throw std::runtime_error("rigging.ini file not found!"); }
@@ -615,7 +615,7 @@ void VantL::LoadIni()
     char section[256];
     char param[256];
 
-    auto const file_path = fio->base_directory_path(BaseDirectory::Config) / RIGGING_INI_FILE;
+    auto const file_path = fio->base_directory_path(BaseDirectory::Ini) / RIGGING_INI_FILE;
     if (fio->exists(file_path)) { ft_old = fio->last_write_time(file_path); }
     auto ini = fio->open_ini_file(file_path);
     if (!ini) { throw std::runtime_error("rigging.ini file not found!"); }
@@ -686,7 +686,7 @@ void VantZ::LoadIni()
     char section[256];
     char param[256];
 
-    auto const file_path = fio->base_directory_path(BaseDirectory::Config) / RIGGING_INI_FILE;
+    auto const file_path = fio->base_directory_path(BaseDirectory::Ini) / RIGGING_INI_FILE;
     if (fio->exists(file_path)) { ft_old = fio->last_write_time(file_path); }
     auto ini = fio->open_ini_file(file_path);
     if (!ini) { throw std::runtime_error("rigging.ini file not found!"); }

--- a/src/libs/rigging/vant.cpp
+++ b/src/libs/rigging/vant.cpp
@@ -32,17 +32,21 @@ VANT_BASE::VANT_BASE()
 VANT_BASE::~VANT_BASE()
 {
     TEXTURE_RELEASE(RenderService, texl);
-    STORM_DELETE(TextureName);
+    delete[] TextureName;
+    TextureName = nullptr;
     while (groupQuantity > 0) {
         groupQuantity--;
-        STORM_DELETE(gdata[groupQuantity].vantIdx);
+        delete[] gdata[groupQuantity].vantIdx;
     }
-    STORM_DELETE(gdata);
+    delete[] gdata;
+    gdata = nullptr;
     while (vantQuantity > 0) {
         vantQuantity--;
         STORM_DELETE(vlist[vantQuantity]);
     }
-    STORM_DELETE(vlist);
+    delete[] vlist;
+    vlist = nullptr;
+
     VERTEX_BUFFER_RELEASE(RenderService, vBuf);
     INDEX_BUFFER_RELEASE(RenderService, iBuf);
     nVert = nIndx = 0;
@@ -178,7 +182,7 @@ uint64_t VANT_BASE::ProcessMessage(MESSAGE& message)
         if (vantQuantity == oldvantQuantity)  // there were no shrouds - delete the whole group
         {
             if (groupQuantity == 1) {
-                delete gdata;
+                delete[] gdata;
                 gdata         = nullptr;
                 groupQuantity = 0;
             } else {
@@ -189,7 +193,7 @@ uint64_t VANT_BASE::ProcessMessage(MESSAGE& message)
                     gdata = oldgdata;
                 else {
                     memcpy(gdata, oldgdata, sizeof(GROUPDATA) * groupQuantity);
-                    delete oldgdata;
+                    delete[] oldgdata;
                 }
             }
             return 0;

--- a/src/libs/sea/sea.cpp
+++ b/src/libs/sea/sea.cpp
@@ -142,21 +142,35 @@ Sea::~Sea()
     if (iFoamTexture >= 0) rs->TextureRelease(iFoamTexture);
     iFoamTexture = -1;
 
-    STORM_DELETE(pIndices);
-    STORM_DELETE(pVSea);
+    delete[] pIndices;
+    pIndices = nullptr;
+
+    delete[] pVSea;
+    pVSea = nullptr;
 
     for (int32_t i = 0; i < aBumpMaps.size(); i++)
         rs->Release(aBumpMaps[i]);
 
-    for (int32_t i = 0; i < aBumps.size(); i++)
-        STORM_DELETE(aBumps[i]);
-    for (int32_t i = 0; i < aNormals.size(); i++)
-        STORM_DELETE(aNormals[i]);
+    for (int32_t i = 0; i < aBumps.size(); i++) {
+        delete[] aBumps[i];
+        aBumps[i] = nullptr;
+    }
+    for (int32_t i = 0; i < aNormals.size(); i++) {
+        delete[] aNormals[i];
+        aNormals[i] = nullptr;
+    }
 
-    STORM_DELETE(pSeaFrame1);
-    STORM_DELETE(pSeaFrame2);
-    STORM_DELETE(pSeaNormalsFrame1);
-    STORM_DELETE(pSeaNormalsFrame2);
+    delete[] pSeaFrame1;
+    pSeaFrame1 = nullptr;
+
+    delete[] pSeaFrame2;
+    pSeaFrame2 = nullptr;
+
+    delete[] pSeaNormalsFrame1;
+    pSeaNormalsFrame1 = nullptr;
+
+    delete[] pSeaNormalsFrame2;
+    pSeaNormalsFrame2 = nullptr;
 }
 
 void Sea::SFLB_CreateBuffers()
@@ -263,8 +277,10 @@ bool Sea::Init()
             }
     }
 
-    for (i = 0; i < aTmpBumps.size(); i++)
-        STORM_DELETE(aTmpBumps[i]);
+    for (i = 0; i < aTmpBumps.size(); i++) {
+        delete[] aTmpBumps[i];
+        aTmpBumps[i] = nullptr;
+    }
 
     BuildVolumeTexture();
 

--- a/src/libs/sea_foam/seafoam.cpp
+++ b/src/libs/sea_foam/seafoam.cpp
@@ -48,7 +48,7 @@ bool SeaFoam::Init()
     soundService = static_cast<VSoundService*>(core->GetService("SoundService"));
 
     // FIXME: hardcode
-    psIni = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Config) / "particles.ini");
+    psIni = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Ini) / "particles.ini");
 
     InitializeShipFoam();
 

--- a/src/libs/sink_effect/sink_effect.cpp
+++ b/src/libs/sink_effect/sink_effect.cpp
@@ -114,7 +114,7 @@ void SinkEffect::Execute(uint32_t _dTime)
 void SinkEffect::InitializeSinks()
 {
     // FIXME: hardcode
-    auto psIni = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Config) / "particles.ini");
+    auto psIni = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Ini) / "particles.ini");
 
     for (auto i = 0; i < sink_effect::MAX_SINKS; ++i) {
         sinks[i].Release();

--- a/src/libs/sound_service/sound_service.cpp
+++ b/src/libs/sound_service/sound_service.cpp
@@ -397,7 +397,7 @@ void SoundService::load_alias_file(std::string const& filename)
 
 void SoundService::init_aliases()
 {
-    auto const filenames = fio->string_paths_by_mask(fio->base_directory_path(BaseDirectory::Aliases), "*.toml", false);
+    auto const filenames = fio->string_paths_by_mask(fio->base_directory_path(BaseDirectory::Aliases), "*.ini", false);
     for (auto const& cur_name: filenames) {
         load_alias_file(cur_name);
     }
@@ -610,7 +610,7 @@ void SoundService::reset_scheme()
 bool SoundService::add_scheme(std::string_view const& scheme_name)
 {
     static char temp_string[COMMON_STRING_LENGTH];
-    auto        ini = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Config) / SCHEME_INI_NAME);
+    auto        ini = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Ini) / SCHEME_INI_NAME);
 
     if (!ini) { return false; }
 

--- a/src/libs/weather/sun_glow.cpp
+++ b/src/libs/weather/sun_glow.cpp
@@ -28,10 +28,13 @@ SunGlow::SunGlow()
     bHaveGlow       = false;
     bHaveOverflow   = false;
     bHaveReflection = false;
+    bVisibleFlare   = false;
 
     idRectBuf = -1;
 
     fBottomClip = 0.f;
+
+    Overflow = {};
 }
 
 SunGlow::~SunGlow()

--- a/src/libs/xinterface/help_chooser/help_chooser.cpp
+++ b/src/libs/xinterface/help_chooser/help_chooser.cpp
@@ -190,9 +190,9 @@ bool HelpChooser::RunChooser(char const* ChooserGroup)
 
     if (ChooserGroup == nullptr) return false;
     // FIXME: hardcode
-    auto ini = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Config) / "helpchooser.ini");
+    auto ini = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Ini) / "helpchooser.ini");
     if (!ini) {
-        core->Trace("Can`t open INI file \"%s/helpchooser.ini\"", fio->base_directory_path(BaseDirectory::Config).string().c_str());
+        core->Trace("Can`t open INI file \"%s/helpchooser.ini\"", fio->base_directory_path(BaseDirectory::Ini).string().c_str());
         return false;
     }
 

--- a/src/libs/xinterface/inode.cpp
+++ b/src/libs/xinterface/inode.cpp
@@ -34,7 +34,8 @@ CINODE::~CINODE()
 {
     STORM_DELETE(m_strHelpTextureFile);
 
-    STORM_DELETE(m_nodeName);
+    delete[] m_nodeName;
+    m_nodeName = nullptr;
 
     if (m_list) {
         m_list->ReleaseAll();
@@ -42,8 +43,11 @@ CINODE::~CINODE()
     }
 
     for (auto i = 0; i < COMMAND_QUANTITY; i++) {
-        STORM_DELETE(m_pCommands[i].sRetControl);
-        STORM_DELETE(m_pCommands[i].sEventName);
+        delete[] m_pCommands[i].sRetControl;
+        m_pCommands[i].sRetControl = nullptr;
+
+        delete[] m_pCommands[i].sEventName;
+        m_pCommands[i].sEventName = nullptr;
 
         auto* pContrl = m_pCommands[i].pNextControl;
         while (pContrl != nullptr) {

--- a/src/libs/xinterface/inode.h
+++ b/src/libs/xinterface/inode.h
@@ -143,7 +143,8 @@ public:
 
         ~COMMAND_REDIRECT()
         {
-            STORM_DELETE(sControlName);
+            delete[] sControlName;
+            sControlName = nullptr;
         }
     };
 

--- a/src/libs/xinterface/nodes/xi_button.cpp
+++ b/src/libs/xinterface/nodes/xi_button.cpp
@@ -229,7 +229,9 @@ void CXI_BUTTON::LoadIni(INIFILE* ini1, char const* name1, INIFILE* ini2, char c
 void CXI_BUTTON::ReleaseAll()
 {
     PICTURE_TEXTURE_RELEASE(pPictureService, m_sGroupName, m_idTex);
-    STORM_DELETE(m_sGroupName);
+    delete[] m_sGroupName;
+    m_sGroupName = nullptr;
+
     FONT_RELEASE(m_rs, m_nFontNum);
     VIDEOTEXTURE_RELEASE(m_rs, m_pTex);
 }

--- a/src/libs/xinterface/nodes/xi_formt_text.cpp
+++ b/src/libs/xinterface/nodes/xi_formt_text.cpp
@@ -559,7 +559,7 @@ void CXI_FORMATEDTEXT::ReleaseString(STRING_DESCRIBER* pCur)
     if (pCur->next) pCur->next->prev = pCur->prev;
     pCur->next = pCur->prev = nullptr;
     m_nAllTextStrings--;
-    STORM_DELETE(pCur->lineStr);
+    delete[] pCur->lineStr;
     delete pCur;
 }
 
@@ -694,7 +694,7 @@ void CXI_FORMATEDTEXT::SetFormatedText(char const* str)
     while (m_listRoot != nullptr) {
         m_listCur  = m_listRoot;
         m_listRoot = m_listRoot->next;
-        STORM_DELETE(m_listCur->lineStr);
+        delete[] m_listCur->lineStr;
         STORM_DELETE(m_listCur);
     }
     m_nStringGroupQuantity = 0;

--- a/src/libs/xinterface/nodes/xi_image.cpp
+++ b/src/libs/xinterface/nodes/xi_image.cpp
@@ -277,7 +277,8 @@ void CXI_IMAGE::Unload()
         }
     }
     RELEASE(m_pTexture);
-    STORM_DELETE(m_pcPictureListName);
+    delete[] m_pcPictureListName;
+    m_pcPictureListName = nullptr;
 }
 
 bool CXI_IMAGE::IsPointInside(int32_t nX, int32_t nY) const

--- a/src/libs/xinterface/nodes/xi_img_collection.cpp
+++ b/src/libs/xinterface/nodes/xi_img_collection.cpp
@@ -45,7 +45,8 @@ void CXI_IMGCOLLECTION::ReleaseAll()
     PICTURE_TEXTURE_RELEASE(pPictureService, sGroupName, texl);
     VERTEX_BUFFER_RELEASE(m_rs, vBuf);
     INDEX_BUFFER_RELEASE(m_rs, iBuf);
-    STORM_DELETE(sGroupName);
+    delete[] sGroupName;
+    sGroupName = nullptr;
 }
 
 int CXI_IMGCOLLECTION::CommandExecute(int wActCode)

--- a/src/libs/xinterface/nodes/xi_picture.cpp
+++ b/src/libs/xinterface/nodes/xi_picture.cpp
@@ -378,7 +378,9 @@ void CXI_PICTURE::ReleasePicture()
 {
     PICTURE_TEXTURE_RELEASE(pPictureService, m_pcGroupName, m_idTex);
 
-    STORM_DELETE(m_pcGroupName);
+    delete[] m_pcGroupName;
+    m_pcGroupName = nullptr;
+
     TEXTURE_RELEASE(m_rs, m_idTex);
     VIDEOTEXTURE_RELEASE(m_rs, m_pTex);
 }

--- a/src/libs/xinterface/nodes/xi_str_collection.cpp
+++ b/src/libs/xinterface/nodes/xi_str_collection.cpp
@@ -155,13 +155,14 @@ void CXI_STRCOLLECTION::LoadIni(INIFILE* ini1, char const* name1, INIFILE* ini2,
 void CXI_STRCOLLECTION::ReleaseAll()
 {
     for (auto i = 0; i < m_nStr; i++) {
-        STORM_DELETE(m_pStrDescr[i].strID);
-        STORM_DELETE(m_pStrDescr[i].strStr);
-        STORM_DELETE(m_pStrDescr[i].sFontName);
+        delete[] m_pStrDescr[i].strID;
+        delete[] m_pStrDescr[i].strStr;
+        delete[] m_pStrDescr[i].sFontName;
         FONT_RELEASE(m_rs, m_pStrDescr[i].nFontNum);
     }
-    STORM_DELETE(m_pStrDescr);
-    m_nStr = 0;
+    delete[] m_pStrDescr;
+    m_pStrDescr = nullptr;
+    m_nStr      = 0;
 }
 
 bool CXI_STRCOLLECTION::IsClick(int buttonID, int32_t xPos, int32_t yPos)

--- a/src/libs/xinterface/nodes/xi_text_button.cpp
+++ b/src/libs/xinterface/nodes/xi_text_button.cpp
@@ -531,8 +531,13 @@ void CXI_TEXTBUTTON::ReleaseAll()
 {
     PICTURE_TEXTURE_RELEASE(pPictureService, m_sGroupName, m_idTex);
     TEXTURE_RELEASE(m_rs, m_idShadowTex);
-    STORM_DELETE(m_sGroupName);
-    STORM_DELETE(m_sString);
+
+    delete[] m_sGroupName;
+    m_sGroupName = nullptr;
+
+    delete[] m_sString;
+    m_sString = nullptr;
+
     VERTEX_BUFFER_RELEASE(m_rs, m_idVBuf);
     INDEX_BUFFER_RELEASE(m_rs, m_idIBuf);
     VIDEOTEXTURE_RELEASE(m_rs, m_pTex);

--- a/src/libs/xinterface/nodes/xi_title.cpp
+++ b/src/libs/xinterface/nodes/xi_title.cpp
@@ -56,7 +56,9 @@ bool CXI_TITLE::Init(
 void CXI_TITLE::ReleaseAll()
 {
     PICTURE_TEXTURE_RELEASE(pPictureService, m_sGroupName, m_idTex);
-    STORM_DELETE(m_sGroupName);
+    delete[] m_sGroupName;
+    m_sGroupName = nullptr;
+
     m_idString = -1L;
     VERTEX_BUFFER_RELEASE(m_rs, m_idVBuf);
     INDEX_BUFFER_RELEASE(m_rs, m_idIBuf);

--- a/src/libs/xinterface/nodes/xi_window.cpp
+++ b/src/libs/xinterface/nodes/xi_window.cpp
@@ -86,9 +86,9 @@ void CXI_WINDOW::SetActive(bool bActive)
     // pass through all nodes and lock / unlock them
     for (int32_t n = 0; n < m_aNodeNameList.size(); n++) {
         auto* const pNod = ptrOwner->FindNode(m_aNodeNameList[n].c_str(), nullptr);
-        if (pNod) {
+        if (pNod != nullptr) {
             pNod->m_bLockedNode = !bActive;
-            if (pNod->m_nNodeType == NODETYPE_WINDOW) static_cast<CXI_WINDOW*>(pNod)->SetActive(bActive);
+            if (pNod->m_nNodeType == NODETYPE_WINDOW) { static_cast<CXI_WINDOW*>(pNod)->SetActive(bActive); }
         }
     }
 }

--- a/src/libs/xinterface/string_service/str_service.cpp
+++ b/src/libs/xinterface/string_service/str_service.cpp
@@ -175,7 +175,7 @@ void StrService::SetLanguage(char const* sLanguage)
     if (m_sLanguage != nullptr && storm::iEquals(sLanguage, m_sLanguage)) return;
 
     // initialize ini file
-    auto langIni = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Config) / sLanguageFile);
+    auto langIni = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Ini) / sLanguageFile);
     if (!langIni) {
         core->Trace("ini file %s not found!", sLanguageFile.data());
         return;
@@ -229,10 +229,10 @@ void StrService::SetLanguage(char const* sLanguage)
     if (RenderService) {
         auto fullIniPath = std::filesystem::path();
         if (langIni->ReadString("FONTS", m_sLanguage, param, sizeof(param) - 1, "")) {
-            fullIniPath = fio->base_directory_path(BaseDirectory::Config) / param;
+            fullIniPath = fio->base_directory_path(BaseDirectory::Ini) / param;
         } else {
             core->Trace("Warning: Not found font record for language %s", m_sLanguage);
-            fullIniPath = fio->base_directory_path(BaseDirectory::Config) / "fonts.ini";
+            fullIniPath = fio->base_directory_path(BaseDirectory::Ini) / "fonts.ini";
         }
         RenderService->SetFontIniFileName(fullIniPath.string().c_str());
     }
@@ -257,7 +257,7 @@ void StrService::SetLanguage(char const* sLanguage)
     }
 
     // initialize ini file
-    auto const ini_path = fio->base_directory_path(BaseDirectory::Config) / "texts" / m_sLanguageDir / m_sIniFileName;
+    auto const ini_path = fio->base_directory_path(BaseDirectory::Ini) / "texts" / m_sLanguageDir / m_sIniFileName;
     auto       ini      = fio->open_ini_file(ini_path);
     if (!ini) {
         core->Trace("WARNING! ini file \"%s\" not found!", ini_path.string().c_str());
@@ -408,7 +408,7 @@ void StrService::LoadIni()
     char param[256];
 
     // initialize ini file
-    auto ini = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Config) / sLanguageFile);
+    auto ini = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Ini) / sLanguageFile);
     if (!ini) {
         core->Trace("Error: Language ini file not found!");
         return;
@@ -486,7 +486,7 @@ int32_t StrService::OpenUsersStringFile(char const* fileName)
     auto pUSB = std::make_unique<UsersStringBlock>();
 
     // strings reading
-    auto const ini_path = fio->base_directory_path(BaseDirectory::Config) / "texts" / m_sLanguageDir / fileName;
+    auto const ini_path = fio->base_directory_path(BaseDirectory::Ini) / "texts" / m_sLanguageDir / fileName;
     auto       fileS    = fio->open_file<std::ifstream>(ini_path, std::ios::binary);
     if (!fileS.is_open()) {
         spdlog::warn("WARNING! Strings file \"{}\" does not exist", fileName);

--- a/src/libs/xinterface/texture_sequence/texture_sequence.cpp
+++ b/src/libs/xinterface/texture_sequence/texture_sequence.cpp
@@ -57,7 +57,7 @@ IDirect3DTexture9* TextureSequence::Initialize(VDX9RENDER* pRS, char const* cTSf
     m_pRS = pRS;
 
     // open ini file
-    auto ini = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Config) / INI_FILENAME);
+    auto ini = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Ini) / INI_FILENAME);
     if (!ini) {
         core->Trace("ini file %s not found!", INI_FILENAME.data());
         return nullptr;

--- a/src/libs/xinterface/xinterface.cpp
+++ b/src/libs/xinterface/xinterface.cpp
@@ -889,7 +889,7 @@ void XInterface::LoadIni()
     // GUARD(XINTERFACE::LoadIni());
     char section[256];
 
-    auto ini = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Config) / RESOURCE_FILENAME);
+    auto ini = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Ini) / RESOURCE_FILENAME);
     if (!ini) throw std::runtime_error("ini file not found!");
 
     auto windowSize = core->GetWindow()->GetWindowSize();
@@ -1020,7 +1020,7 @@ void XInterface::LoadDialog(char const* sFileName)
         return;
     }
     // FIXME: hardcode
-    auto ownerIni = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Config) / "interfaces" / "defaultnode.ini");
+    auto ownerIni = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Ini) / "interfaces" / "defaultnode.ini");
 
     sprintf_s(section, "MAIN");
 
@@ -1138,7 +1138,7 @@ void XInterface::CreateNode(char const* sFileName, char const* sNodeType, char c
         }
     }
     // FIXME: hardcode
-    auto ownerIni = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Config) / "interfaces" / "defaultnode.ini");
+    auto ownerIni = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Ini) / "interfaces" / "defaultnode.ini");
 
     SFLB_CreateNode(ownerIni.get(), ini.get(), sNodeType, sNodeName, priority);
 }

--- a/src/libs/xinterface/xinterface.cpp
+++ b/src/libs/xinterface/xinterface.cpp
@@ -1908,7 +1908,8 @@ CINODE* XInterface::GetActivingNode(CINODE* findRoot)
 void XInterface::MouseMove()
 {
     if (m_nInterfaceMode == CONTEXTHELP_IMODE) return;
-    CONTROL_STATE csv, csh;
+    CONTROL_STATE csv = {};
+    CONTROL_STATE csh = {};
     core->Controls->GetControlState(INTERFACE_MOUSE_VERT, csv);
     core->Controls->GetControlState(INTERFACE_MOUSE_HORZ, csh);
 
@@ -2131,7 +2132,9 @@ void XInterface::ReleaseOld()
 
     oldKeyState.dwKeyCode = 0;
     for (int i = 0; i < m_nStringQuantity; i++) {
-        STORM_DELETE(m_stringes[i].sStringName);
+        delete[] m_stringes[i].sStringName;
+        m_stringes[i].sStringName = nullptr;
+
         FONT_RELEASE(pRenderService, m_stringes[i].fontNum);
     }
     m_nStringQuantity = 0;
@@ -2644,7 +2647,7 @@ char* AddAttributesStringsToBuffer(char* inBuffer, char* prevStr, ATTRIBUTES* pA
             strcat_s(pNew, nadd, "=");
             strcat_s(pNew, nadd, attrVal);
 
-            delete inBuffer;
+            delete[] inBuffer;
             inBuffer = pNew;
         }
 
@@ -2677,7 +2680,7 @@ void XInterface::SaveOptionsFile(char const* fileName, ATTRIBUTES* pAttr)
 
     if (pOutBuffer) {
         fileS.write(pOutBuffer, strlen(pOutBuffer));
-        delete pOutBuffer;
+        delete[] pOutBuffer;
     }
 }
 

--- a/src/libs/xinterface/xinterface.h
+++ b/src/libs/xinterface/xinterface.h
@@ -376,8 +376,11 @@ protected:
 
         ~EVENT_Entity()
         {
-            STORM_DELETE(sEventName);
-            STORM_DELETE(sNodeName);
+            delete[] sEventName;
+            sEventName = nullptr;
+            delete[] sNodeName;
+            sNodeName = nullptr;
+
             nCommandIndex = 0;
         }
     };

--- a/src/libs/xinterface/xservice.cpp
+++ b/src/libs/xinterface/xservice.cpp
@@ -253,7 +253,7 @@ void XSERVICE::LoadAllPicturesInfo()
             if (m_pImage == nullptr) throw std::runtime_error("allocate memory error");
             if (oldpImage != nullptr) {
                 memcpy(m_pImage, oldpImage, m_dwImageQuantity * sizeof(PICTUREDESCR));
-                delete oldpImage;
+                delete[] oldpImage;
             }
             m_dwImageQuantity += m_pList[i].pictureQuantity;
 
@@ -288,20 +288,20 @@ void XSERVICE::ReleaseAll()
         for (auto i = 0; i < m_dwListQuantity; i++) {
             if (m_pList[i].textureQuantity != 0) m_pRS->TextureRelease(m_pList[i].textureID);
 
-            delete m_pList[i].sImageListName;
+            delete[] m_pList[i].sImageListName;
 
-            delete m_pList[i].sTextureName;
+            delete[] m_pList[i].sTextureName;
         }
 
-        delete m_pList;
+        delete[] m_pList;
     }
 
     if (m_pImage != nullptr) {
         for (auto i = 0; i < m_dwImageQuantity; i++) {
-            delete m_pImage[i].sPictureName;
+            delete[] m_pImage[i].sPictureName;
         }
 
-        delete m_pImage;
+        delete[] m_pImage;
     }
 
     m_dwListQuantity  = 0;

--- a/src/libs/xinterface/xservice.cpp
+++ b/src/libs/xinterface/xservice.cpp
@@ -204,7 +204,7 @@ void XSERVICE::LoadAllPicturesInfo()
     char param[255];
 
     // initialize ini file
-    auto ini = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Config) / LISTS_INIFILE);
+    auto ini = fio->open_ini_file(fio->base_directory_path(BaseDirectory::Ini) / LISTS_INIFILE);
     if (!ini) { throw std::runtime_error("ini file not found!"); }
 
     m_dwListQuantity  = 0;

--- a/src/libs/xinterface/xutil.cpp
+++ b/src/libs/xinterface/xutil.cpp
@@ -77,7 +77,7 @@ void DublicateString(char*& pDstStr, char const* pSrcStr)
     {
         pDstStr = nullptr;
     } else {
-        delete pDstStr;
+        delete[] pDstStr;
         auto const len = strlen(pSrcStr) + 1;
         pDstStr        = new char[len];
         Assert(pDstStr);


### PR DESCRIPTION
Well, I've changed my mind. There is no many reasons to switch to any new config parsers.
INI configs are readable and works fine. They need a custom parser, but it is not much of a problem.

So I wrote a new parser - much simpler and more readable than the old one. For now it's only engine.ini and aliases usages that are adapted for new parser. Aliases files itself are remain unchanged, so no converting required.
engine.ini refactored a bit and some key names are renamed and moved to specific sections (this is not final and additional adjustments are possible)